### PR TITLE
feat: replace alert() with toast notifications, closes #120

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,36 +1,80 @@
-/* Toggle Code Block */
-function toggleCode(id) {
-  const el = document.getElementById(id);
+/* TOAST NOTIFICATION */
+function showToast(message) {
 
-  if (el.style.display === "block") {
-    el.style.display = "none";
-  } else {
-    el.style.display = "block";
-  }
+  const existing = document.getElementById("toast-notification");
+  if (existing) existing.remove();
+ 
+  const toast = document.createElement("div");
+  toast.id = "toast-notification";
+  toast.className = "toast";
+  toast.textContent = message;
+ 
+  document.body.appendChild(toast);
+ 
+  // Trigger slide-in
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      toast.classList.add("toast-visible");
+    });
+  });
+ 
+  // Auto-dismiss after 2 seconds
+  setTimeout(() => {
+    toast.classList.remove("toast-visible");
+    toast.classList.add("toast-hidden");
+    toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+  }, 2000);
 }
+ 
+/* TOGGLE CODE BLOCK */
 function toggleCode(id) {
   const codeBlock = document.getElementById(id);
-  
   if (codeBlock.style.display === "block") {
     codeBlock.style.display = "none";
   } else {
     codeBlock.style.display = "block";
   }
 }
-/* Toggle Sidebar on mobile and desktop */
+ 
+/* COPY CODE */
+function copyCode(id, btn) {
+  const code = document.getElementById(id).innerText;
+ 
+  navigator.clipboard.writeText(code)
+    .then(() => {
+      showToast("Code copied!");
+ 
+      if (btn) {
+        btn.innerText = "Copied!";
+        btn.style.background = "#00b894";
+        setTimeout(() => {
+          btn.innerText = "Copy";
+          btn.style.background = "#111";
+        }, 1500);
+      }
+    })
+    .catch(() => {
+      if (btn) btn.innerText = "Error";
+    });
+}
+ 
+/* COPY COLOR */
+function copyColor(color) {
+  navigator.clipboard.writeText(color);
+  showToast(color + " copied!");
+}
+ 
+/* SIDEBAR TOGGLE */
 function toggleSidebar() {
   if (window.innerWidth <= 900) {
     document.body.classList.toggle('sidebar-open');
   } else {
     const isHidden = document.body.classList.toggle('sidebar-hidden');
-    /* Persist desktop sidebar state across page navigations */
     sessionStorage.setItem('sidebarHidden', isHidden ? '1' : '0');
   }
 }
-
-/* Active link helper for sidebar navigation */
+ 
 function updateSidebarActiveLink() {
-  /* Normalize to lowercase so 'Navbar.html' matches href='navbar.html' */
   const currentPage = (window.location.pathname.split('/').pop() || 'index.html').toLowerCase();
   document.querySelectorAll('.sidebar ul li').forEach((li) => {
     const anchor = li.querySelector('a');
@@ -42,15 +86,13 @@ function updateSidebarActiveLink() {
     }
   });
 }
-
-/* Restore sidebar hidden state on desktop across page navigations */
+ 
 function restoreSidebarState() {
   if (window.innerWidth > 900 && sessionStorage.getItem('sidebarHidden') === '1') {
     document.body.classList.add('sidebar-hidden');
   }
 }
-
-/* Close mobile sidebar when a nav link is clicked */
+ 
 function initSidebarLinkClose() {
   document.querySelectorAll('.sidebar ul li a').forEach((anchor) => {
     anchor.addEventListener('click', function () {
@@ -60,95 +102,64 @@ function initSidebarLinkClose() {
     });
   });
 }
-
+ 
 window.addEventListener('DOMContentLoaded', function () {
   restoreSidebarState();
   updateSidebarActiveLink();
   initSidebarLinkClose();
 });
-
-/* Copy Code with Better UX */
-function copyCode(id, btn) {
-  const code = document.getElementById(id).innerText;
-
-  navigator.clipboard.writeText(code)
-    .then(() => {
-      btn.innerText = "Copied!";
-      btn.style.background = "#00b894";
-
-      setTimeout(() => {
-        btn.innerText = "Copy";
-        btn.style.background = "#111";
-      }, 1500);
-    })
-    .catch(() => {
-      btn.innerText = "Error";
-    });
-}
+ 
+/* SEARCH (INLINE FILTER) */
 const searchInput = document.getElementById("searchInput");
 const components = document.querySelectorAll(".component-card");
-
+ 
 if (searchInput) {
   searchInput.addEventListener("keyup", function () {
     const value = this.value.toLowerCase();
-
     components.forEach((item) => {
       const text = item.dataset.name.toLowerCase();
-
-      if (text.includes(value)) {
-        item.style.display = "block";
-      } else {
-        item.style.display = "none";
-      }
+      item.style.display = text.includes(value) ? "block" : "none";
     });
   });
 }
+ 
+/* SEARCH (PAGE ROUTING) */
 function handleSearch(event) {
   if (event.key === "Enter") {
     const query = event.target.value.toLowerCase().trim();
-
-    // 🔥 Mapping keywords → pages
+ 
     const routes = {
-      "button": "button.html",
+      "button":  "button.html",
       "buttons": "button.html",
-
-      "navbar": "navbar.html",
+      "navbar":  "navbar.html",
       "navbars": "navbar.html",
-
-      "card": "cards.html",
-      "cards": "cards.html",
-
-      "form": "form.html",
-      "forms": "form.html",
-
-      "footer": "footer.html",
-      "color": "color.html",
-      "colors": "color.html"
+      "card":    "cards.html",
+      "cards":   "cards.html",
+      "form":    "form.html",
+      "forms":   "form.html",
+      "footer":  "footer.html",
+      "color":   "color.html",
+      "colors":  "color.html"
     };
-
-    // 🔍 Find match
+ 
     for (let key in routes) {
       if (query.includes(key)) {
         window.location.href = routes[key];
         return;
       }
     }
-
-    // ❌ No match
-    alert("No component found 😢");
+ 
+    showToast("No component found 😢");
   }
 }
-// 🌙 DARK MODE TOGGLE (ADDED)
-
+ 
+/* DARK MODE TOGGLE */
 const toggleBtn = document.getElementById("theme-toggle");
-
-// Check if button exists (important for multi-pages)
+ 
 if (toggleBtn) {
-
-  // Toggle on click
   toggleBtn.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
-
+ 
     if (document.body.classList.contains("dark-mode")) {
       localStorage.setItem("theme", "dark");
       toggleBtn.innerText = "☀️ Light Mode";
@@ -157,30 +168,12 @@ if (toggleBtn) {
       toggleBtn.innerText = "🌙 Dark Mode";
     }
   });
-
-  // Load saved theme
+ 
   window.addEventListener("DOMContentLoaded", () => {
     const savedTheme = localStorage.getItem("theme");
-
     if (savedTheme === "dark") {
       document.body.classList.add("dark-mode");
       toggleBtn.innerText = "☀️ Light Mode";
     }
-
   });
-}
-function toggleCode(id) {
-  const el = document.getElementById(id);
-  el.style.display = (el.style.display === "block") ? "none" : "block";
-}
-
-function copyCode(id) {
-  const code = document.getElementById(id).innerText;
-  navigator.clipboard.writeText(code);
-  alert("Code copied!");
-}
-
-function copyColor(color) {
-  navigator.clipboard.writeText(color);
-  alert(color + " copied!");
 }

--- a/style.css
+++ b/style.css
@@ -733,3 +733,40 @@ nav a:hover {
 .student-card .profile-btn:hover {
   background: #000;
 }
+/* =====================
+   TOAST NOTIFICATION
+   ===================== */
+.toast {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  background: #222;
+  color: #fff;
+  padding: 12px 22px;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-family: Arial, sans-serif;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.22);
+  z-index: 9999;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+}
+
+.toast.toast-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.toast-hidden {
+  opacity: 0;
+  transform: translateY(16px);
+}
+
+/* Dark mode support */
+body.dark-mode .toast {
+  background: #f0f0f0;
+  color: #111;
+  box-shadow: 0 4px 18px rgba(255, 255, 255, 0.1);
+}


### PR DESCRIPTION
Changes Made
- Added 'showToast(message)' function in 'script.js'
- Replaced all 3 'alert()' calls in 'copyCode()', 'copyColor()', and 'handleSearch()'
- Added toast styles + slide-in/fade-out animation in 'style.css'
- Toast auto-dismisses after 2 seconds with no user interaction
- Works in both light and dark mode
- Cleaned up duplicate 'toggleCode' and 'copyCode' function definitions

Closes #120