### PR TITLE
Fix: dark mode persistence across pages

### DIFF
--- a/script.js
+++ b/script.js
@@ -154,26 +154,25 @@ function handleSearch(event) {
 }
  
 /* DARK MODE TOGGLE */
-const toggleBtn = document.getElementById("theme-toggle");
- 
-if (toggleBtn) {
-  toggleBtn.addEventListener("click", () => {
-    document.body.classList.toggle("dark-mode");
- 
+window.addEventListener("DOMContentLoaded", () => {
+  if (localStorage.getItem("theme") === "dark") {
+    document.body.classList.add("dark-mode");
+  }
+
+  const toggleBtn = document.getElementById("theme-toggle");
+  if (toggleBtn) {
     if (document.body.classList.contains("dark-mode")) {
-      localStorage.setItem("theme", "dark");
-      toggleBtn.innerText = "☀️ Light Mode";
-    } else {
-      localStorage.setItem("theme", "light");
-      toggleBtn.innerText = "🌙 Dark Mode";
-    }
-  });
- 
-  window.addEventListener("DOMContentLoaded", () => {
-    const savedTheme = localStorage.getItem("theme");
-    if (savedTheme === "dark") {
-      document.body.classList.add("dark-mode");
       toggleBtn.innerText = "☀️ Light Mode";
     }
-  });
-}
+    toggleBtn.addEventListener("click", () => {
+      document.body.classList.toggle("dark-mode");
+      if (document.body.classList.contains("dark-mode")) {
+        localStorage.setItem("theme", "dark");
+        toggleBtn.innerText = "☀️ Light Mode";
+      } else {
+        localStorage.setItem("theme", "light");
+        toggleBtn.innerText = "🌙 Dark Mode";
+      }
+    });
+  }
+});


### PR DESCRIPTION
### 📝 **Description:**

#### 🐛 Problem

Currently, the dark mode preference is stored in `localStorage`, but it is only applied on the `index.html` page. Other pages (like `button.html`, `cards.html`, `navbar.html`, etc.) do not restore the saved theme on load.

This happens because the theme restoration logic in `script.js` is conditionally executed only when the toggle button is present (`if (toggleBtn)`), causing inconsistent UI behavior across the app.

---

#### ✅ Solution

* Refactored the theme initialization logic to run **independently of the toggle button**
* Ensured that the saved theme is applied globally on **every page load**
* Kept the toggle functionality intact for user interaction

---

#### 🔧 Changes Made

* Moved theme restoration logic outside of conditional checks
* Applied theme state (`dark` / `light`) during initial script execution
* Ensured consistency across all HTML pages using the same script

---

#### 🎯 Result

* Dark mode now persists across **all pages**
* Consistent user experience throughout the application 🌙✨

---

#### 🧪 How to Test

1. Open `index.html`
2. Toggle dark mode
3. Navigate to other pages (e.g., `cards.html`, `button.html`)
4. ✅ Dark mode should remain applied


#### 📸 Screenshots 

<img width="1916" height="875" alt="image" src="https://github.com/user-attachments/assets/69d683a5-1035-4e37-83f9-8bb0c6238d26" />




---

Fixes issue #142

Hiii @Tushar-sonawane06 , do review it !!

## 🏷️ Program 
This PR is submitted as part of **NSoC (Nexus Spring of Code)**.
