### PR TITLE
fix: correct license name from MIT to Apache 2.0 in CONTRIBUTING.md

### DIFF
--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -40,7 +40,7 @@ By participating in this project, you agree to maintain a **respectful and inclu
 
 ## 📜 License
 
-By contributing to this project, you agree that your contributions will be licensed under the [`MIT License`](https://github.com/Tushar-sonawane06/UI-Verse/blob/main/Docs/LICENSE.md).
+By contributing to this project, you agree that your contributions will be licensed under the [`Apache License 2.0`](https://github.com/Tushar-sonawane06/UI-Verse/blob/main/Docs/LICENSE.md).
 
 ![Line](https://user-images.githubusercontent.com/85225156/171937799-8fc9e255-9889-4642-9c92-6df85fb86e82.gif)
 


### PR DESCRIPTION
Fixes #181

## Problem
CONTRIBUTING.md stated that contributions would be licensed 
under the MIT License, but the actual LICENSE.md file contains 
the Apache License 2.0.

## Fix
Updated CONTRIBUTING.md to correctly reference Apache License 2.0 
instead of MIT License.

## Files Changed
- Docs/CONTRIBUTING.md

NSoC'26