### PR TITLE
Badge page responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -744,3 +744,15 @@ body.dark-mode .hero-left p {
   margin-top: 10px;
 } 
 
+/* badge responsive */
+
+@media (max-width: 1440px) {
+
+  .sidebar {
+    width: 100%;
+    height: auto;
+    position: relative;
+  }
+
+}
+


### PR DESCRIPTION
resolve issue : #237 

before: 

<img width="1596" height="869" alt="Screenshot 2026-05-03 195540" src="https://github.com/user-attachments/assets/0231908e-d6fa-4c75-8bf4-b971020a8143" />

After : 

<img width="1561" height="804" alt="Screenshot 2026-05-03 195850" src="https://github.com/user-attachments/assets/352f3631-4623-4f0b-b990-8d89881d4163" />
