### PR TITLE
Normalize: standardize page titles across component pages

### DIFF
--- a/badges.html
+++ b/badges.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Show Badges</title>
+    <title>Badges — UIverse</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contact Us — UIverse</title>
+  <title>Contact — UIverse</title>
 
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
Normalize page titles across component pages to follow a consistent, predictable naming pattern site-wide.

## What I changed
Updated the following page titles in the `<title>` tags:
- `badges.html`: "Show Badges" → "Badges — UIverse"
- `contact.html`: "Contact Us — UIverse" → "Contact — UIverse"
- `forms.html`: Already "Forms — UIverse" (confirmed)

## Why
Inconsistent page titles make metadata unpredictable and reduce site professionalism. Following a consistent pattern `[ComponentName] — UIverse` ensures:
- ✅ Consistent browser tab labels
- ✅ Better search engine indexing and clarity
- ✅ Improved user experience (users know what page they're viewing)
- ✅ Alignment with site-wide naming conventions

## Pattern reference
Aligned with existing pages:
- "Buttons — UIverse"
- "Cards — UIverse"
- "Navbars — UIverse"
- "Loaders — UIverse"
- etc.

## Related issues
Closes: Issue #400

## Checklist
- [x] All page titles follow a consistent pattern
- [x] No functionality or styling changes
- [x] Verified across 3 affected files