### PR TITLE
fix: Inline event handlers call functions with the wrong signature / missing parameters

### DIFF
--- a/alerts.html
+++ b/alerts.html
@@ -52,7 +52,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a1')">View Code</button>
+          <button onclick="toggleCode('a1', this)">View Code</button>
           <button onclick="copyCode('a1', this)">Copy</button>
         </div>
 
@@ -74,7 +74,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a2')">View Code</button>
+          <button onclick="toggleCode('a2', this)">View Code</button>
           <button onclick="copyCode('a2', this)">Copy</button>
         </div>
 
@@ -96,7 +96,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a3')">View Code</button>
+          <button onclick="toggleCode('a3', this)">View Code</button>
           <button onclick="copyCode('a3', this)">Copy</button>
         </div>
 
@@ -118,7 +118,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a4')">View Code</button>
+          <button onclick="toggleCode('a4', this)">View Code</button>
           <button onclick="copyCode('a4', this)">Copy</button>
         </div>
 
@@ -140,7 +140,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a5')">View Code</button>
+          <button onclick="toggleCode('a5', this)">View Code</button>
           <button onclick="copyCode('a5', this)">Copy</button>
         </div>
 
@@ -162,7 +162,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a6')">View Code</button>
+          <button onclick="toggleCode('a6', this)">View Code</button>
           <button onclick="copyCode('a6', this)">Copy</button>
         </div>
 
@@ -185,7 +185,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a7')">View Code</button>
+          <button onclick="toggleCode('a7', this)">View Code</button>
           <button onclick="copyCode('a7', this)">Copy</button>
         </div>
 
@@ -211,7 +211,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a8')">View Code</button>
+          <button onclick="toggleCode('a8', this)">View Code</button>
           <button onclick="copyCode('a8', this)">Copy</button>
         </div>
 
@@ -233,7 +233,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a9')">View Code</button>
+          <button onclick="toggleCode('a9', this)">View Code</button>
           <button onclick="copyCode('a9', this)">Copy</button>
         </div>
 
@@ -254,7 +254,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a10')">View Code</button>
+          <button onclick="toggleCode('a10', this)">View Code</button>
           <button onclick="copyCode('a10', this)">Copy</button>
         </div>
 
@@ -278,7 +278,7 @@
         </div>
 
         <div class="actions">
-          <button onclick="toggleCode('a11')">View Code</button>
+          <button onclick="toggleCode('a11', this)">View Code</button>
           <button onclick="copyCode('a11', this)">Copy</button>
         </div>
 

--- a/button.html
+++ b/button.html
@@ -287,8 +287,8 @@
         <button class="gradient-btn">Click Me</button>
 
         <div class="actions">
-          <button onclick="toggleCode('c1')">View Code</button>
-          <button onclick="copyCode('c1',this)">Copy</button>
+          <button onclick="toggleCode('c1', this)">View Code</button>
+          <button onclick="copyCode('c1', this)">Copy</button>
         </div>
 
         <pre id="c1" class="code-block">
@@ -334,8 +334,8 @@
         <button class="outline-btn">Click Me</button>
 
         <div class="actions">
-          <button onclick="toggleCode('c2')">View Code</button>
-          <button onclick="copyCode('c2',this)">Copy</button>
+          <button onclick="toggleCode('c2', this)">View Code</button>
+          <button onclick="copyCode('c2', this)">Copy</button>
         </div>
 
         <pre id="c2" class="code-block">
@@ -381,8 +381,8 @@
         <button class="neon-btn">Glow</button>
 
         <div class="actions">
-          <button onclick="toggleCode('c3')">View Code</button>
-          <button onclick="copyCode('c3',this)">Copy</button>
+          <button onclick="toggleCode('c3', this)">View Code</button>
+          <button onclick="copyCode('c3', this)">Copy</button>
         </div>
 
         <pre id="c3" class="code-block">
@@ -428,8 +428,8 @@
         <button class="glass-btn">Glass</button>
 
         <div class="actions">
-          <button onclick="toggleCode('c4')">View Code</button>
-          <button onclick="copyCode('c4',this)">Copy</button>
+          <button onclick="toggleCode('c4', this)">View Code</button>
+          <button onclick="copyCode('c4', this)">Copy</button>
         </div>
 
         <pre id="c4" class="code-block">

--- a/form.html
+++ b/form.html
@@ -74,8 +74,8 @@
         </form>
         
         <div class="actions">
-          <button onclick="toggleCode('f1')">View Code</button>
-          <button onclick="copyCode('f1',this)">Copy</button>
+          <button onclick="toggleCode('f1', this)">View Code</button>
+          <button onclick="copyCode('f1', this)">Copy</button>
         </div>
 <pre id="f1" class="code-block">
 &lt;form&gt;
@@ -98,8 +98,8 @@
     </form>
 
     <div class="actions">
-      <button onclick="toggleCode('f2')">View Code</button>
-      <button onclick="copyCode('f2',this)">Copy</button>
+      <button onclick="toggleCode('f2', this)">View Code</button>
+      <button onclick="copyCode('f2', this)">Copy</button>
     </div>
 
 <pre id="f2" class="code-block">
@@ -124,8 +124,8 @@
     </form>
 
     <div class="actions">
-      <button onclick="toggleCode('f3')">View Code</button>
-      <button onclick="copyCode('f3',this)">Copy</button>
+      <button onclick="toggleCode('f3', this)">View Code</button>
+      <button onclick="copyCode('f3', this)">Copy</button>
     </div>
 
 <pre id="f3" class="code-block">
@@ -302,8 +302,8 @@
       </form>
     </div>
     <div class="actions">
-      <button onclick="toggleCode('f4')">View Code</button>
-      <button onclick="copyCode('f4',this)">Copy</button>
+      <button onclick="toggleCode('f4', this)">View Code</button>
+      <button onclick="copyCode('f4', this)">Copy</button>
     </div>
     <pre id="f4" class="code-block">
 &lt;form class="newsletter-form"&gt;
@@ -341,8 +341,8 @@
       </form>
     </div>
     <div class="actions">
-      <button onclick="toggleCode('f5')">View Code</button>
-      <button onclick="copyCode('f5',this)">Copy</button>
+      <button onclick="toggleCode('f5', this)">View Code</button>
+      <button onclick="copyCode('f5', this)">Copy</button>
     </div>
     <pre id="f5" class="code-block">
 &lt;form class="search-form"&gt;
@@ -380,8 +380,8 @@
       </form>
     </div>
     <div class="actions">
-      <button onclick="toggleCode('f6')">View Code</button>
-      <button onclick="copyCode('f6',this)">Copy</button>
+      <button onclick="toggleCode('f6', this)">View Code</button>
+      <button onclick="copyCode('f6', this)">Copy</button>
     </div>
     <pre id="f6" class="code-block">
 &lt;form class="feedback-form"&gt;
@@ -414,8 +414,8 @@
       </form>
     </div>
     <div class="actions">
-      <button onclick="toggleCode('f7')">View Code</button>
-      <button onclick="copyCode('f7',this)">Copy</button>
+      <button onclick="toggleCode('f7', this)">View Code</button>
+      <button onclick="copyCode('f7', this)">Copy</button>
     </div>
     <pre id="f7" class="code-block">
 &lt;form class="password-reset-form"&gt;
@@ -450,8 +450,8 @@
       </form>
     </div>
     <div class="actions">
-      <button onclick="toggleCode('f8')">View Code</button>
-      <button onclick="copyCode('f8',this)">Copy</button>
+      <button onclick="toggleCode('f8', this)">View Code</button>
+      <button onclick="copyCode('f8', this)">Copy</button>
     </div>
     <pre id="f8" class="code-block">
 &lt;form class="profile-update-form"&gt;
@@ -492,8 +492,8 @@
       </form>
     </div>
     <div class="actions">
-      <button onclick="toggleCode('f9')">View Code</button>
-      <button onclick="copyCode('f9',this)">Copy</button>
+      <button onclick="toggleCode('f9', this)">View Code</button>
+      <button onclick="copyCode('f9', this)">Copy</button>
     </div>
     <pre id="f9" class="code-block">
 &lt;form class="job-application-form"&gt;
@@ -541,8 +541,8 @@
       </form>
     </div>
     <div class="actions">
-      <button onclick="toggleCode('f10')">View Code</button>
-      <button onclick="copyCode('f10',this)">Copy</button>
+      <button onclick="toggleCode('f10', this)">View Code</button>
+      <button onclick="copyCode('f10', this)">Copy</button>
     </div>
     <pre id="f10" class="code-block">
 &lt;form class="event-registration-form"&gt;

--- a/loaders.html
+++ b/loaders.html
@@ -193,8 +193,8 @@
       </div>
 
       <div class="actions">
-        <button onclick="toggleCode('loader1')">View Code</button>
-        <button onclick="copyCode('loader1')">Copy</button>
+        <button onclick="toggleCode('loader1', this)">View Code</button>
+        <button onclick="copyCode('loader1', this)">Copy</button>
       </div>
 
       <pre id="loader1" class="code-block">
@@ -213,8 +213,8 @@
       </div>
 
       <div class="actions">
-        <button onclick="toggleCode('loader2')">View Code</button>
-        <button onclick="copyCode('loader2')">Copy</button>
+        <button onclick="toggleCode('loader2', this)">View Code</button>
+        <button onclick="copyCode('loader2', this)">Copy</button>
       </div>
 
       <pre id="loader2" class="code-block">
@@ -239,8 +239,8 @@
       </div>
 
       <div class="actions">
-        <button onclick="toggleCode('loader3')">View Code</button>
-        <button onclick="copyCode('loader3')">Copy</button>
+        <button onclick="toggleCode('loader3', this)">View Code</button>
+        <button onclick="copyCode('loader3', this)">Copy</button>
       </div>
 
       <pre id="loader3" class="code-block">
@@ -263,8 +263,8 @@
       </div>
 
       <div class="actions">
-        <button onclick="toggleCode('loader4')">View Code</button>
-        <button onclick="copyCode('loader4')">Copy</button>
+        <button onclick="toggleCode('loader4', this)">View Code</button>
+        <button onclick="copyCode('loader4', this)">Copy</button>
       </div>
 
       <pre id="loader4" class="code-block">
@@ -287,8 +287,8 @@
       </div>
 
       <div class="actions">
-        <button onclick="toggleCode('loader5')">View Code</button>
-        <button onclick="copyCode('loader5')">Copy</button>
+        <button onclick="toggleCode('loader5', this)">View Code</button>
+        <button onclick="copyCode('loader5', this)">Copy</button>
       </div>
 
       <pre id="loader5" class="code-block">
@@ -319,8 +319,8 @@
       </div>
 
       <div class="actions">
-        <button onclick="toggleCode('loader6')">View Code</button>
-        <button onclick="copyCode('loader6')">Copy</button>
+        <button onclick="toggleCode('loader6', this)">View Code</button>
+        <button onclick="copyCode('loader6', this)">Copy</button>
       </div>
 
       <pre id="loader6" class="code-block">
@@ -349,8 +349,8 @@
       </div>
 
       <div class="actions">
-        <button onclick="toggleCode('loader7')">View Code</button>
-        <button onclick="copyCode('loader7')">Copy</button>
+        <button onclick="toggleCode('loader7', this)">View Code</button>
+        <button onclick="copyCode('loader7', this)">Copy</button>
       </div>
 
       <pre id="loader7" class="code-block">

--- a/span.html
+++ b/span.html
@@ -68,8 +68,8 @@
       <p>This is a <span class="highlight">highlighted text</span> example.</p>
 
       <div class="actions">
-        <button onclick="toggleCode('s1')">View Code</button>
-        <button onclick="copyCode('s1',this)">Copy</button>
+        <button onclick="toggleCode('s1', this)">View Code</button>
+        <button onclick="copyCode('s1', this)">Copy</button>
       </div>
 
 <pre id="s1" class="code-block">
@@ -83,8 +83,8 @@
       <p>Notifications <span class="badge">3</span></p>
 
       <div class="actions">
-        <button onclick="toggleCode('s2')">View Code</button>
-        <button onclick="copyCode('s2',this)">Copy</button>
+        <button onclick="toggleCode('s2', this)">View Code</button>
+        <button onclick="copyCode('s2', this)">Copy</button>
       </div>
 
 <pre id="s2" class="code-block">
@@ -101,8 +101,8 @@
       <span class="tag-span">CSS</span>
 
       <div class="actions">
-        <button onclick="toggleCode('s3')">View Code</button>
-        <button onclick="copyCode('s3',this)">Copy</button>
+        <button onclick="toggleCode('s3', this)">View Code</button>
+        <button onclick="copyCode('s3', this)">Copy</button>
       </div>
 
 <pre id="s3" class="code-block">
@@ -119,8 +119,8 @@
       <p>Status: <span class="status offline">Offline</span></p>
 
       <div class="actions">
-        <button onclick="toggleCode('s4')">View Code</button>
-        <button onclick="copyCode('s4',this)">Copy</button>
+        <button onclick="toggleCode('s4', this)">View Code</button>
+        <button onclick="copyCode('s4', this)">Copy</button>
       </div>
 
 <pre id="s4" class="code-block">
@@ -137,8 +137,8 @@
       <span class="pill success">Success</span>
 
       <div class="actions">
-        <button onclick="toggleCode('s5')">View Code</button>
-        <button onclick="copyCode('s5',this)">Copy</button>
+        <button onclick="toggleCode('s5', this)">View Code</button>
+        <button onclick="copyCode('s5', this)">Copy</button>
       </div>
 
 <pre id="s5" class="code-block">
@@ -156,8 +156,8 @@
       </span>
 
       <div class="actions">
-        <button onclick="toggleCode('s6')">View Code</button>
-        <button onclick="copyCode('s6',this)">Copy</button>
+        <button onclick="toggleCode('s6', this)">View Code</button>
+        <button onclick="copyCode('s6', this)">Copy</button>
       </div>
 
 <pre id="s6" class="code-block">

--- a/testimonials.html
+++ b/testimonials.html
@@ -132,7 +132,7 @@
 
         <div class="actions">
 
-          <button onclick="toggleCode('t1')">
+          <button onclick="toggleCode('t1', this)">
             View Code
           </button>
 
@@ -199,7 +199,7 @@
 
         <div class="actions">
 
-          <button onclick="toggleCode('t2')">
+          <button onclick="toggleCode('t2', this)">
             View Code
           </button>
 

--- a/toggles.html
+++ b/toggles.html
@@ -166,8 +166,8 @@
         </div>
       </div>
       <div class="actions">
-        <button onclick="toggleCode('togCode1')">View Code</button>
-        <button onclick="copyCode('togCode1')">Copy</button>
+        <button onclick="toggleCode('togCode1', this)">View Code</button>
+        <button onclick="copyCode('togCode1', this)">Copy</button>
       </div>
       <pre id="togCode1" class="code-block">&lt;input type="checkbox" id="myToggle"&gt;
 &lt;label for="myToggle"&gt;&lt;/label&gt;
@@ -204,8 +204,8 @@ input[type="checkbox"] { display: none; }
         </div>
       </div>
       <div class="actions">
-        <button onclick="toggleCode('togCode2')">View Code</button>
-        <button onclick="copyCode('togCode2')">Copy</button>
+        <button onclick="toggleCode('togCode2', this)">View Code</button>
+        <button onclick="copyCode('togCode2', this)">Copy</button>
       </div>
       <pre id="togCode2" class="code-block">&lt;input type="checkbox" id="myToggle" checked&gt;
 &lt;label for="myToggle"&gt;&lt;/label&gt;
@@ -241,8 +241,8 @@ input[type="checkbox"] { display: none; }
         </div>
       </div>
       <div class="actions">
-        <button onclick="toggleCode('togCode3')">View Code</button>
-        <button onclick="copyCode('togCode3')">Copy</button>
+        <button onclick="toggleCode('togCode3', this)">View Code</button>
+        <button onclick="copyCode('togCode3', this)">Copy</button>
       </div>
       <pre id="togCode3" class="code-block">&lt;input type="checkbox" id="myToggle"&gt;
 &lt;label for="myToggle"&gt;&lt;/label&gt;
@@ -285,8 +285,8 @@ input[type="checkbox"] { display: none; }
         </div>
       </div>
       <div class="actions">
-        <button onclick="toggleCode('togCode4')">View Code</button>
-        <button onclick="copyCode('togCode4')">Copy</button>
+        <button onclick="toggleCode('togCode4', this)">View Code</button>
+        <button onclick="copyCode('togCode4', this)">Copy</button>
       </div>
       <pre id="togCode4" class="code-block">&lt;input type="checkbox" id="myToggle"&gt;
 &lt;label for="myToggle"&gt;&lt;/label&gt;
@@ -330,8 +330,8 @@ input[type="checkbox"] { display: none; }
         </div>
       </div>
       <div class="actions">
-        <button onclick="toggleCode('togCode5')">View Code</button>
-        <button onclick="copyCode('togCode5')">Copy</button>
+        <button onclick="toggleCode('togCode5', this)">View Code</button>
+        <button onclick="copyCode('togCode5', this)">Copy</button>
       </div>
       <pre id="togCode5" class="code-block">&lt;input type="checkbox" id="myToggle" checked&gt;
 &lt;label for="myToggle"&gt;&lt;/label&gt;


### PR DESCRIPTION
**Update:** I updated inline handlers to pass the button (`this`) so `toggleCode(id, btn)` / `copyCode(id, btn)` work consistently.

- **Files updated:** toggles.html, form.html, span.html, loaders.html, testimonials.html
- **What changed:** Replaced one-arg calls like `toggleCode('id')` / `copyCode('id')` with two-arg calls `toggleCode('id', this)` / `copyCode('id', this)` so the consolidated script.js can update button text/status.
- **Current status:** script.js has a single `DOMContentLoaded` initializer and robust `toggleCode(id, btn)` and `copyCode(id, btn)` implementations (optional `btn` supported).

closes #476