### PR TITLE
fix: Duplicate / conflicting theme-toggle logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,20 +463,6 @@
 
 <script src="script.js"></script>
 <script>
-  // Dark mode toggle
-  const toggle = document.getElementById('darkModeToggle');
-  const icon = toggle.querySelector('i');
-  if (localStorage.getItem('theme') === 'dark') {
-    document.body.classList.add('dark-mode');
-    icon.className = 'fa-solid fa-sun';
-  }
-  toggle.addEventListener('click', () => {
-    document.body.classList.toggle('dark-mode');
-    const isDark = document.body.classList.contains('dark-mode');
-    icon.className = isDark ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
-  });
-
   // Sidebar toggle
   function toggleSidebar() {
     const sidebar = document.getElementById('sidebar');

--- a/script.js
+++ b/script.js
@@ -539,7 +539,7 @@ function handleSearch(event) {
 // Dark mode
 function updateToggleVisual(toggleEl, isDark) { const icon = toggleEl?.querySelector?.('i'); if (icon) icon.className = isDark ? 'fa-solid fa-sun' : 'fa-solid fa-moon'; else toggleEl.innerText = isDark ? '☀️ Light Mode' : '🌙 Dark Mode'; }
 function loadTheme(toggleEl) { const saved = localStorage.getItem('theme'); if (saved === 'dark') { document.body.classList.add('dark-mode'); if (toggleEl) updateToggleVisual(toggleEl, true); } else if (saved === 'light') { document.body.classList.remove('dark-mode'); if (toggleEl) updateToggleVisual(toggleEl, false); } else { const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches; document.body.classList.toggle('dark-mode', prefersDark); if (toggleEl) updateToggleVisual(toggleEl, prefersDark); } }
-function initDarkMode() { const toggleEl = document.getElementById('theme-toggle') || document.getElementById('themeToggle') || document.getElementById('darkModeToggle'); loadTheme(toggleEl); if (toggleEl) toggleEl.addEventListener('click', () => { document.body.classList.toggle('dark-mode'); const isDark = document.body.classList.contains('dark-mode'); localStorage.setItem('theme', isDark ? 'dark' : 'light'); updateToggleVisual(toggleEl, isDark); }); }
+function initDarkMode() { const toggleEl = document.getElementById('darkModeToggle'); loadTheme(toggleEl); if (!toggleEl) return; toggleEl.addEventListener('click', () => { document.body.classList.toggle('dark-mode'); const isDark = document.body.classList.contains('dark-mode'); localStorage.setItem('theme', isDark ? 'dark' : 'light'); updateToggleVisual(toggleEl, isDark); }); }
 
 // Accessibility Mode
 function scanA11yIssues() {


### PR DESCRIPTION
Removed the duplicate inline dark-mode handler from index.html and kept the remaining inline script wrapped correctly. In script.js, `initDarkMode()` now binds only to `darkModeToggle`, while preserving the existing icon swap and `localStorage` theme persistence.

Validation: script.js is clean. The HTML checker still reports several pre-existing issues in index.html, but they are unrelated to the theme-toggle change.


closes #673