### PR TITLE
feat: Implement side-by-side component compare mode

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Component Compare — UI-Verse</title>
+  <link rel="stylesheet" href="css/main.css">
+  <style>
+    body { font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; margin: 0; }
+    .toolbar { background: #fff; border-bottom: 1px solid #e6e6e6; padding: 12px 16px; display:flex; gap:12px; align-items:center; }
+    .select { padding:6px 8px; }
+    .controls { margin-left: auto; display:flex; gap:8px; align-items:center; }
+    .layout { display:flex; height: calc(100vh - 56px); }
+    .pane { flex:1; border-right:1px solid #eee; display:flex; flex-direction:column; }
+    .pane:last-child { border-right: none; }
+    .pane header { padding:8px 12px; background:#fafafa; border-bottom:1px solid #eee; display:flex; gap:8px; align-items:center; }
+    .view { flex:1; }
+    iframe { width:100%; height:100%; border:0; display:block; }
+    .muted { color:#666; font-size:0.9rem; }
+    button { padding:6px 10px; }
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <label>
+      Left:
+      <select id="leftSelect" class="select"></select>
+    </label>
+
+    <label>
+      Right:
+      <select id="rightSelect" class="select"></select>
+    </label>
+
+    <div class="controls">
+      <button id="swapBtn">Swap</button>
+      <label class="muted"><input type="checkbox" id="syncScroll"> Sync scroll</label>
+      <button id="openBoth">Open Both in New Tabs</button>
+    </div>
+  </div>
+
+  <div class="layout">
+    <div class="pane">
+      <header><strong id="leftTitle">Left</strong></header>
+      <div class="view"><iframe id="leftFrame" title="Left preview"></iframe></div>
+    </div>
+
+    <div class="pane">
+      <header><strong id="rightTitle">Right</strong></header>
+      <div class="view"><iframe id="rightFrame" title="Right preview"></iframe></div>
+    </div>
+  </div>
+
+  <script src="js/features/compare.js"></script>
+</body>
+</html>

--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -1,0 +1,127 @@
+(function(){
+  const leftSelect = document.getElementById('leftSelect');
+  const rightSelect = document.getElementById('rightSelect');
+  const leftFrame = document.getElementById('leftFrame');
+  const rightFrame = document.getElementById('rightFrame');
+  const swapBtn = document.getElementById('swapBtn');
+  const syncCheckbox = document.getElementById('syncScroll');
+  const openBoth = document.getElementById('openBoth');
+  const leftTitle = document.getElementById('leftTitle');
+  const rightTitle = document.getElementById('rightTitle');
+
+  // Load component list from data/components.json
+  async function loadComponents(){
+    try{
+      const res = await fetch('data/components.json');
+      if(!res.ok) throw new Error('Failed fetching components.json');
+      const list = await res.json();
+      populateSelect(leftSelect, list);
+      populateSelect(rightSelect, list);
+
+      // default picks from URL params
+      const params = new URLSearchParams(location.search);
+      const l = params.get('left') || list[0] && list[0].path;
+      const r = params.get('right') || list[1] && list[1].path || list[0] && list[0].path;
+      if(l) leftSelect.value = l;
+      if(r) rightSelect.value = r;
+      loadFrames();
+    }catch(err){
+      console.error(err);
+      // fallback: bare inputs
+      leftSelect.innerHTML = '<option value="index.html">index.html</option>';
+      rightSelect.innerHTML = '<option value="index.html">index.html</option>';
+    }
+  }
+
+  function populateSelect(sel, list){
+    sel.innerHTML = '';
+    list.forEach(item => {
+      const opt = document.createElement('option');
+      opt.value = item.path;
+      opt.textContent = item.title + ' — ' + item.path;
+      sel.appendChild(opt);
+    });
+  }
+
+  function loadFrames(){
+    const left = leftSelect.value;
+    const right = rightSelect.value;
+    leftFrame.src = left || 'index.html';
+    rightFrame.src = right || 'index.html';
+    leftTitle.textContent = left || 'Left';
+    rightTitle.textContent = right || 'Right';
+    // update URL
+    const params = new URLSearchParams();
+    if(left) params.set('left', left);
+    if(right) params.set('right', right);
+    history.replaceState(null, '', '?' + params.toString());
+  }
+
+  swapBtn.addEventListener('click', () => {
+    const a = leftSelect.value;
+    leftSelect.value = rightSelect.value;
+    rightSelect.value = a;
+    loadFrames();
+  });
+
+  leftSelect.addEventListener('change', loadFrames);
+  rightSelect.addEventListener('change', loadFrames);
+
+  openBoth.addEventListener('click', () => {
+    window.open(leftSelect.value, '_blank');
+    window.open(rightSelect.value, '_blank');
+  });
+
+  // Sync scroll logic: best-effort, only works when same-origin (file:// allowed in many browsers)
+  let syncing = false;
+  function syncScroll(sourceFrame, targetFrame){
+    if(!syncCheckbox.checked) return;
+    try{
+      const sdoc = sourceFrame.contentWindow.document;
+      const tdoc = targetFrame.contentWindow.document;
+      const sTop = sourceFrame.contentWindow.scrollY || sourceFrame.contentWindow.pageYOffset || 0;
+      const sHeight = sdoc.documentElement.scrollHeight - sourceFrame.clientHeight;
+      const ratio = sHeight > 0 ? sTop / sHeight : 0;
+      const tHeight = tdoc.documentElement.scrollHeight - targetFrame.clientHeight;
+      const targetTop = Math.round(ratio * Math.max(0, tHeight));
+      targetFrame.contentWindow.scrollTo(0, targetTop);
+    }catch(e){
+      // cross-origin or not yet loaded; ignore
+    }
+  }
+
+  function attachScrollSync(frameA, frameB){
+    function onScroll(){
+      if(syncing) return;
+      syncing = true;
+      syncScroll(frameA, frameB);
+      setTimeout(()=> syncing = false, 30);
+    }
+    try{
+      frameA.addEventListener('load', () => {
+        try{
+          frameA.contentWindow.addEventListener('scroll', onScroll, { passive: true });
+        }catch(e){}
+      });
+    }catch(e){}
+  }
+
+  // Setup basic mutual sync when frames load
+  leftFrame.addEventListener('load', () => {
+    if(syncCheckbox.checked){
+      attachScrollSync(leftFrame, rightFrame);
+    }
+  });
+  rightFrame.addEventListener('load', () => {
+    if(syncCheckbox.checked){
+      attachScrollSync(rightFrame, leftFrame);
+    }
+  });
+
+  syncCheckbox.addEventListener('change', () => {
+    // no-op; listeners re-attach on next load events
+  });
+
+  // Initialize
+  loadComponents();
+})();


### PR DESCRIPTION
### Summary
Add a lightweight side-by-side compare view so designers/devs can preview two component pages simultaneously and quickly inspect differences.

### Files changed
- Added: `compare.html` — new compare UI page (left/right panes, toolbar)
- Added: `js/features/compare.js` — loads `data/components.json`, populates selectors, supports swap, URL params, open-both, and best-effort scroll sync

### How to use
1. Run a local server (recommended) or open `compare.html` in the browser.
2. Pick components from the Left/Right dropdowns, or pass URL params:
   - `compare.html?left=button.html&right=cards.html`
3. Options:
   - Swap pages with "Swap"
   - Check "Sync scroll" for best-effort scroll syncing (same-origin pages)
   - "Open Both in New Tabs" opens each page in a new tab

## ISSUE RESOLVED #915 