### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a reproducible bug or broken behavior
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## Problem
+Describe the bug clearly.
+
+## Current Behavior
+What happens today?
+
+## Expected Behavior
+What should happen instead?
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Screenshots
+Add screenshots if they help explain the issue.
+
+## Additional Context
+Share any other details that might help reproduce the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an improvement or new component
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+What gap or limitation are you trying to solve?
+
+## Proposed Improvement
+Describe the feature or enhancement you want.
+
+## Why It Matters
+Explain the value or user impact.
+
+## Expected Result
+Describe the outcome after the change.
+
+## Additional Context
+Add examples, references, or related ideas.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Related Issue
+Closes #
+
+## Summary
+Briefly explain what this pull request changes.
+
+## Changes Made
+- 
+- 
+- 
+
+## Testing
+Describe how you verified the change locally.
+
+## Screenshots
+Add screenshots if the change affects the UI.
+
+## Checklist
+- [ ] Code follows project style
+- [ ] Tested locally
+- [ ] No unrelated changes included

--- a/Docs/CONTRIBUTING.md
+++ b/Docs/CONTRIBUTING.md
@@ -153,6 +153,7 @@ We aim to keep things smooth and transparent:
 - Take a look at the existing [Issues](https://github.com/Tushar-sonawane06/UI-Verse/issues). 
 - Fork the Repo & create a branch for any issue that you are working on and commit your work.
 - At first raise an issue in which you want to work
+- Use the GitHub issue template for bug reports or feature requests so maintainers can triage them consistently.
 - Then after assigning only then work on that issue & make a PR 
 - Create a [**Pull Request**](https://github.com/Tushar-sonawane06/UI-Verse/pulls), which will be promptly reviewed and given suggestions for improvements by the community.
 - **REMINDER: Don't raise more than 2 `Issue` at a time**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌸 Nexus Spring of Code Project
 
-# 🚀 UIverse – Frontend Component Hub
+## 🚀 UIverse – Frontend Component Hub
 
 🔗 **GitHub Repository:**
 https://github.com/Tushar-sonawane06/UI-Verse


### PR DESCRIPTION
# Related Issue

Closes #995 

# Summary

This PR adds repository templates for issues and pull requests so contributors can submit more consistent, reviewable reports.

# Changes Made

- Added a bug report issue template.
- Added a feature request issue template.
- Added a pull request template with issue, testing, and checklist sections.
- Updated the contributor guide to mention the new templates.

# Testing

Verified the new template files are present and confirmed the contributor guide text points to them.

# Screenshots

Not applicable for this docs-only change.

# Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included