### PR TITLE
Improve Span Page UI by Removing Duplicates footer ,side bar, nav bar and Enhancing Layout

### DIFF
--- a/span.html
+++ b/span.html
@@ -37,296 +37,7 @@
 
 <body>
 
-<<<<<<< span
-  
-  <header class="navbar">
-
-    <div class="nav-left">
-
-      <button class="menu-toggle" onclick="toggleSidebar()">
-        <i class="fa-solid fa-bars"></i>
-      </button>
-
-      <div class="logo">
-        <div class="logo-icon">
-          ✦
-        </div>
-
-        <span>UIverse</span>
-      </div>
-
-    </div>
-
-    <div class="search-bar">
-
-      <i class="fa-solid fa-magnifying-glass"></i>
-
-      <input
-        type="text"
-        placeholder="Search modern components..."
-      />
-
-    </div>
-
-    <div class="nav-right">
-
-      <button class="nav-btn ghost">
-        <i class="fa-regular fa-heart"></i>
-        My Collection
-      </button>
-
-      <button class="nav-btn primary">
-        <i class="fa-solid fa-plus"></i>
-        Add Component
-      </button>
-
-    </div>
-
-  </header>
-
-  <aside class="sidebar" id="sidebar">
-
-    <div class="sidebar-top">
-
-      <h2>UIverse</h2>
-
-      <p>
-        Modern UI Component Library
-      </p>
-
-    </div>
-
-    <ul>
-
-      <li>
-        <a href="index.html">
-          <i class="fa-solid fa-house"></i>
-          Home
-        </a>
-      </li>
-
-      <li>
-        <a href="button.html">
-          <i class="fa-solid fa-hand-pointer"></i>
-          Buttons
-        </a>
-      </li>
-
-      <li>
-        <a href="navbar.html">
-          <i class="fa-solid fa-bars"></i>
-          Navbars
-        </a>
-      </li>
-
-      <li>
-        <a href="cards.html">
-          <i class="fa-solid fa-id-card"></i>
-          Cards
-        </a>
-      </li>
-
-      <li>
-        <a href="inputs.html">
-          <i class="fa-solid fa-keyboard"></i>
-          Inputs
-        </a>
-      </li>
-
-      <li>
-        <a href="footer.html">
-          <i class="fa-solid fa-table-columns"></i>
-          Footer
-        </a>
-      </li>
-
-      <li>
-        <a href="form.html">
-          <i class="fa-solid fa-file-lines"></i>
-          Forms
-        </a>
-      </li>
-
-      <li class="active">
-        <a href="span.html">
-          <i class="fa-solid fa-tag"></i>
-          Span Components
-        </a>
-      </li>
-
-      <li>
-        <a href="color.html">
-          <i class="fa-solid fa-palette"></i>
-          Colors
-        </a>
-      </li>
-
-    </ul>
-
-  </aside>
-
-  <!-- Mobile Backdrop -->
-  <div
-    class="sidebar-backdrop"
-    onclick="toggleSidebar()"
-  ></div>
-  <main class="main">
-    <section class="hero">
-
-      <div class="hero-badge">
-
-        <i class="fa-solid fa-wand-magic-sparkles"></i>
-
-        Beautiful Inline Components
-
-      </div>
-
-      <h1>
-
-        Modern
-        <span>Span Components</span>
-
-      </h1>
-
-      <p>
-
-        Discover elegant reusable span-based UI elements
-        designed with gradients, glassmorphism, hover
-        animations, and modern layouts.
-
-      </p>
-
-    </section>
-
-    <section class="grid">
-
-      <div class="component-card">
-
-        <div class="card-top">
-
-          <div class="card-icon blue">
-            <i class="fa-solid fa-highlighter"></i>
-          </div>
-
-          <div>
-
-            <h3>Highlight Text</h3>
-
-            <p>
-              Stylish highlighted inline text
-            </p>
-
-          </div>
-
-        </div>
-
-        <div class="preview-box">
-
-          <p>
-
-            This is a
-            <span class="highlight">
-              highlighted text
-            </span>
-            example.
-
-          </p>
-
-        </div>
-
-        <div class="actions">
-
-          <button onclick="toggleCode('s1')">
-
-            <i class="fa-solid fa-code"></i>
-
-            View Code
-
-          </button>
-
-          <button onclick="copyCode('s1',this)">
-
-            <i class="fa-regular fa-copy"></i>
-
-            Copy
-
-          </button>
-
-        </div>
-
-<pre id="s1" class="code-block">
-&lt;span class="highlight"&gt;
-  highlighted text
-&lt;/span&gt;
-</pre>
-
-      </div>
-
-      <!-- ========================================
-           BADGE
-      ========================================= -->
-      <div class="component-card">
-
-        <div class="card-top">
-
-          <div class="card-icon pink">
-            <i class="fa-solid fa-bell"></i>
-          </div>
-
-          <div>
-
-            <h3>Notification Badge</h3>
-
-            <p>
-              Compact alert counter component
-            </p>
-
-          </div>
-
-        </div>
-
-        <div class="preview-box">
-
-          <p>
-
-            Notifications
-
-            <span class="badge">
-              8
-            </span>
-
-          </p>
-
-        </div>
-
-        <div class="actions">
-
-          <button onclick="toggleCode('s2')">
-
-            <i class="fa-solid fa-code"></i>
-
-            View Code
-
-          </button>
-
-          <button onclick="copyCode('s2',this)">
-
-            <i class="fa-regular fa-copy"></i>
-
-            Copy
-
-          </button>
-
-        </div>
-
-<pre id="s2" class="code-block">
-&lt;span class="badge"&gt;
-  8
-&lt;/span&gt;
-</pre>
-
-=======
-<!-- ================= SIDEBAR ================= -->
+  <!-- ================= SIDEBAR ================= -->
 <aside class="sidebar" id="sidebar">
   <div class="sidebar-brand">
     <span class="brand-icon">⬡</span>
@@ -520,7 +231,6 @@
       <div class="actions">
         <button class="action-btn view-btn" onclick="toggleCode('s3', this)"><i class="fa-solid fa-code"></i> View Code</button>
         <button class="action-btn copy-btn" onclick="copyCode('s3', this)"><i class="fa-solid fa-copy"></i> Copy</button>
->>>>>>> main
       </div>
       <pre id="s3" class="code-block"><code>&lt;span class="tag"&gt;UI&lt;/span&gt;
 &lt;span class="tag red"&gt;Bug&lt;/span&gt;
@@ -542,7 +252,6 @@
 .tag.green  { background: rgba(0,184,148,0.1); border-color: rgba(0,184,148,0.3); color: #00b894; }</code></pre>
     </div>
 
-<<<<<<< span
       <!-- ========================================
      GRADIENT TEXT
 ========================================= -->
@@ -908,398 +617,99 @@
 
 </div>
 
-      <!-- ========================================
-           TAGS
-      ========================================= -->
-      <div class="component-card">
-
-        <div class="card-top">
-
-          <div class="card-icon purple">
-            <i class="fa-solid fa-tags"></i>
-          </div>
-
-          <div>
-
-            <h3>Tag Elements</h3>
-
-            <p>
-              Reusable tag span styles
-            </p>
-
-          </div>
-
-        </div>
-
-        <div class="preview-box">
-
-          <span class="tag-span">
-            UI
-          </span>
-
-          <span class="tag-span">
-            React
-          </span>
-
-          <span class="tag-span">
-            CSS
-          </span>
-
-          <span class="tag-span">
-            Design
-          </span>
-
-        </div>
-
-        <div class="actions">
-
-          <button onclick="toggleCode('s3')">
-
-            <i class="fa-solid fa-code"></i>
-
-            View Code
-
-          </button>
-
-          <button onclick="copyCode('s3',this)">
-
-            <i class="fa-regular fa-copy"></i>
-
-            Copy
-
-          </button>
-
-        </div>
-
-<pre id="s3" class="code-block">
-&lt;span class="tag-span"&gt;
-  UI
-&lt;/span&gt;
-</pre>
-
-=======
-    <!-- Status Indicators -->
-    <div class="component-card" data-name="status online offline busy away indicator" data-cat="status">
-      <div class="card-top">
-        <span class="card-label">Status Indicator</span>
-        <span class="card-tag tag-popular">Popular</span>
-      </div>
-      <div class="card-preview">
-        <div class="preview-status-col">
-          <p>User: <span class="sp-status sp-online">● Online</span></p>
-          <p>User: <span class="sp-status sp-offline">● Offline</span></p>
-          <p>User: <span class="sp-status sp-busy">● Busy</span></p>
-          <p>User: <span class="sp-status sp-away">● Away</span></p>
-        </div>
-      </div>
-      <p class="card-desc">Inline status indicators with dot and label — Online, Offline, Busy, and Away variants.</p>
-      <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('s4', this)"><i class="fa-solid fa-code"></i> View Code</button>
-        <button class="action-btn copy-btn" onclick="copyCode('s4', this)"><i class="fa-solid fa-copy"></i> Copy</button>
-      </div>
-      <pre id="s4" class="code-block"><code>&lt;span class="status online"&gt;● Online&lt;/span&gt;
-&lt;span class="status offline"&gt;● Offline&lt;/span&gt;
-&lt;span class="status busy"&gt;● Busy&lt;/span&gt;
-&lt;span class="status away"&gt;● Away&lt;/span&gt;
-
-.status {
-  padding: 4px 12px;
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 600;
-}
-.status.online  { background: rgba(0,184,148,0.12); color: #00b894; }
-.status.offline { background: rgba(99,110,114,0.12); color: #636e72; }
-.status.busy    { background: rgba(214,48,49,0.12);  color: #d63031; }
-.status.away    { background: rgba(253,203,110,0.15); color: #d98e00; }</code></pre>
-    </div>
-
-    <!-- Pills -->
-    <div class="component-card" data-name="pill label plan tier badge" data-cat="label">
-      <div class="card-top">
-        <span class="card-label">Pill Labels</span>
-        <span class="card-tag tag-trending">Trending</span>
-      </div>
-      <div class="card-preview">
-        <div class="preview-wrap">
-          <span class="sp-pill sp-accent">New</span>
-          <span class="sp-pill sp-success">Active</span>
-          <span class="sp-pill sp-danger">Expired</span>
-          <span class="sp-pill sp-warning">Pending</span>
-          <span class="sp-pill sp-purple">Pro</span>
-          <span class="sp-pill sp-dark">Beta</span>
-        </div>
-      </div>
-      <p class="card-desc">Gradient and solid pill labels — perfect for plan tiers, statuses, and feature flags.</p>
-      <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('s5', this)"><i class="fa-solid fa-code"></i> View Code</button>
-        <button class="action-btn copy-btn" onclick="copyCode('s5', this)"><i class="fa-solid fa-copy"></i> Copy</button>
-      </div>
-      <pre id="s5" class="code-block"><code>&lt;span class="pill"&gt;New&lt;/span&gt;
-&lt;span class="pill success"&gt;Active&lt;/span&gt;
-&lt;span class="pill danger"&gt;Expired&lt;/span&gt;
-&lt;span class="pill warning"&gt;Pending&lt;/span&gt;
-
-.pill {
-  display: inline-block;
-  padding: 5px 14px;
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.3px;
-}
-.pill         { background: var(--accent); color: #fff; }
-.pill.success { background: #00b894; color: #fff; }
-.pill.danger  { background: #d63031; color: #fff; }
-.pill.warning { background: #fdcb6e; color: #333; }
-.pill.purple  { background: #6c5ce7; color: #fff; }
-.pill.dark    { background: #111;    color: #fff; }</code></pre>
-    </div>
-
-    <!-- Tooltip -->
-    <div class="component-card" data-name="tooltip hover popup hint" data-cat="interactive">
-      <div class="card-top">
-        <span class="card-label">Tooltip</span>
-        <span class="card-tag tag-popular">Popular</span>
-      </div>
-      <div class="card-preview">
-        <div class="preview-wrap" style="padding:20px 0;">
-          <span class="sp-tooltip">Hover over me
-            <span class="sp-tooltip-text">This is a tooltip!</span>
-          </span>
-          &nbsp;&nbsp;
-          <span class="sp-tooltip sp-tooltip-bottom">Bottom tooltip
-            <span class="sp-tooltip-text sp-tooltip-text-bottom">Appears below</span>
-          </span>
-        </div>
-      </div>
-      <p class="card-desc">CSS-only tooltips that appear on hover — top and bottom positions available.</p>
-      <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('s6', this)"><i class="fa-solid fa-code"></i> View Code</button>
-        <button class="action-btn copy-btn" onclick="copyCode('s6', this)"><i class="fa-solid fa-copy"></i> Copy</button>
->>>>>>> main
-      </div>
-      <pre id="s6" class="code-block"><code>&lt;span class="tooltip"&gt;Hover me
-  &lt;span class="tooltip-text"&gt;Tooltip!&lt;/span&gt;
-&lt;/span&gt;
-
-<<<<<<< span
-      <!-- ========================================
-           STATUS
-      ========================================= -->
-      <div class="component-card">
-
-        <div class="card-top">
-
-          <div class="card-icon green">
-            <i class="fa-solid fa-signal"></i>
-          </div>
-
-          <div>
-
-            <h3>Status Indicators</h3>
-
-            <p>
-              Online and offline indicators
-            </p>
-
-          </div>
-
-        </div>
-
-        <div class="preview-box">
-
-          <span class="status online">
-            Online
-          </span>
-
-          <span class="status offline">
-            Offline
-          </span>
-
-        </div>
-
-        <div class="actions">
-
-          <button onclick="toggleCode('s4')">
-
-            <i class="fa-solid fa-code"></i>
-
-            View Code
-
-          </button>
-
-          <button onclick="copyCode('s4',this)">
-
-            <i class="fa-regular fa-copy"></i>
-
-            Copy
-
-          </button>
-
-        </div>
-
-<pre id="s4" class="code-block">
-&lt;span class="status online"&gt;
-  Online
-&lt;/span&gt;
-
-&lt;span class="status offline"&gt;
-  Offline
-&lt;/span&gt;
-</pre>
-
-      </div>
-
-      <!-- ========================================
-           PILLS
-      ========================================= -->
-      <div class="component-card">
-
-        <div class="card-top">
-
-          <div class="card-icon orange">
-            <i class="fa-solid fa-capsules"></i>
-          </div>
-
-          <div>
-
-            <h3>Pill Labels</h3>
-
-            <p>
-              Rounded modern label components
-            </p>
-
-          </div>
-
-        </div>
-
-        <div class="preview-box">
-
-          <span class="pill">
-            New
-          </span>
-
-          <span class="pill success">
-            Success
-          </span>
-
-        </div>
-
-        <div class="actions">
-
-          <button onclick="toggleCode('s5')">
-
-            <i class="fa-solid fa-code"></i>
-
-            View Code
-
-          </button>
-
-          <button onclick="copyCode('s5',this)">
-
-            <i class="fa-regular fa-copy"></i>
-
-            Copy
-
-          </button>
-
-        </div>
-
-<pre id="s5" class="code-block">
-&lt;span class="pill"&gt;
-  New
-&lt;/span&gt;
-</pre>
-
-      </div>
-
-      <!-- ========================================
-           TOOLTIP
-      ========================================= -->
-      <div class="component-card">
-
-        <div class="card-top">
-
-          <div class="card-icon cyan">
-            <i class="fa-solid fa-comment-dots"></i>
-          </div>
-
-          <div>
-
-            <h3>Tooltip</h3>
-
-            <p>
-              Interactive hover tooltip component
-            </p>
-
-          </div>
-
-        </div>
-
-        <div class="preview-box">
-
-          <span class="tooltip">
-
-            Hover Me
-
-            <span class="tooltip-text">
-
-              Beautiful tooltip text
-
-            </span>
-
-          </span>
-
-        </div>
-
-        <div class="actions">
-
-          <button onclick="toggleCode('s6')">
-
-            <i class="fa-solid fa-code"></i>
-
-            View Code
-
-          </button>
-
-          <button onclick="copyCode('s6',this)">
-
-            <i class="fa-regular fa-copy"></i>
-
-            Copy
-
-          </button>
-
-        </div>
-
-<pre id="s6" class="code-block">
-&lt;span class="tooltip"&gt;
-
-  Hover Me
-
-  &lt;span class="tooltip-text"&gt;
-    Beautiful tooltip text
-  &lt;/span&gt;
-
-&lt;/span&gt;
-</pre>
-
-      </div>
-=======
-.tooltip { position: relative; cursor: pointer; color: var(--accent); font-weight: 600; }
-.tooltip-text {
-  position: absolute;
-  bottom: 140%; left: 50%;
-  transform: translateX(-50%);
-  background: #111; color: #fff;
-  padding: 8px 14px; border-radius: 8px;
-  white-space: nowrap; font-size: 12px;
-  opacity: 0; visibility: hidden;
-  transition: 0.2s;
-}
-.tooltip:hover .tooltip-text { opacity: 1; visibility: visible; }</code></pre>
-    </div>
+      <!-- Tags -->
+<div class="component-card" data-name="tags ui react css design" data-cat="text">
+  <div class="card-top">
+    <span class="card-label">Tag Elements</span>
+    <span class="card-tag tag-trending">Trending</span>
+  </div>
+  <div class="card-preview">
+    <span class="tag-span">UI</span>
+    <span class="tag-span">React</span>
+    <span class="tag-span">CSS</span>
+    <span class="tag-span">Design</span>
+  </div>
+  <p class="card-desc">Reusable <code class="inline-code">&lt;span&gt;</code> styles for tags and labels.</p>
+  <div class="actions">
+    <button class="action-btn view-btn" onclick="toggleCode('s3', this)">
+      <i class="fa-solid fa-code"></i> View Code
+    </button>
+    <button class="action-btn copy-btn" onclick="copyCode('s3', this)">
+      <i class="fa-solid fa-copy"></i> Copy
+    </button>
+  </div>
+  <pre id="s3" class="code-block"><code>&lt;span class="tag-span"&gt;UI&lt;/span&gt;</code></pre>
+</div>
+
+<!-- Status Indicators -->
+<div class="component-card" data-name="status online offline busy away" data-cat="status">
+  <div class="card-top">
+    <span class="card-label">Status Indicator</span>
+    <span class="card-tag tag-popular">Popular</span>
+  </div>
+  <div class="card-preview">
+    <p>User: <span class="status online">● Online</span></p>
+    <p>User: <span class="status offline">● Offline</span></p>
+    <p>User: <span class="status busy">● Busy</span></p>
+    <p>User: <span class="status away">● Away</span></p>
+  </div>
+  <p class="card-desc">Inline status indicators with dot and label — Online, Offline, Busy, and Away variants.</p>
+  <div class="actions">
+    <button class="action-btn view-btn" onclick="toggleCode('s4', this)">
+      <i class="fa-solid fa-code"></i> View Code
+    </button>
+    <button class="action-btn copy-btn" onclick="copyCode('s4', this)">
+      <i class="fa-solid fa-copy"></i> Copy
+    </button>
+  </div>
+  <pre id="s4" class="code-block"><code>&lt;span class="status online"&gt;● Online&lt;/span&gt;</code></pre>
+</div>
+
+<!-- Pills -->
+<div class="component-card" data-name="pill labels new success" data-cat="labels">
+  <div class="card-top">
+    <span class="card-label">Pill Labels</span>
+    <span class="card-tag tag-new">New</span>
+  </div>
+  <div class="card-preview">
+    <span class="pill">New</span>
+    <span class="pill success">Success</span>
+  </div>
+  <p class="card-desc">Rounded modern pill-style labels for highlighting status or categories.</p>
+  <div class="actions">
+    <button class="action-btn view-btn" onclick="toggleCode('s5', this)">
+      <i class="fa-solid fa-code"></i> View Code
+    </button>
+    <button class="action-btn copy-btn" onclick="copyCode('s5', this)">
+      <i class="fa-solid fa-copy"></i> Copy
+    </button>
+  </div>
+  <pre id="s5" class="code-block"><code>&lt;span class="pill success"&gt;Success&lt;/span&gt;</code></pre>
+</div>
+
+<!-- Tooltip -->
+<div class="component-card" data-name="tooltip hover text" data-cat="interaction">
+  <div class="card-top">
+    <span class="card-label">Tooltip</span>
+    <span class="card-tag tag-trending">Trending</span>
+  </div>
+  <div class="card-preview">
+    <span class="tooltip">
+      Hover Me
+      <span class="tooltip-text">Beautiful tooltip text</span>
+    </span>
+  </div>
+  <p class="card-desc">Interactive hover tooltip component with styled text bubble.</p>
+  <div class="actions">
+    <button class="action-btn view-btn" onclick="toggleCode('s6', this)">
+      <i class="fa-solid fa-code"></i> View Code
+    </button>
+    <button class="action-btn copy-btn" onclick="copyCode('s6', this)">
+      <i class="fa-solid fa-copy"></i> Copy
+    </button>
+  </div>
+  <pre id="s6" class="code-block"><code>&lt;span class="tooltip"&gt;Hover Me&lt;/span&gt;</code></pre>
+</div>
 
     <!-- Keyboard Shortcut -->
     <div class="component-card" data-name="keyboard shortcut kbd key hotkey" data-cat="text">
@@ -1585,145 +995,13 @@ function copyTag(el, text) {
     </div>
 
   </div><!-- /span-grid -->
->>>>>>> main
 
     </section>
 
-<<<<<<< span
   </main>
 
-  <!-- ========================================
-       FOOTER
-  ========================================= -->
-  <footer class="footer">
-
-    <div class="footer-container">
-
-      <div class="footer-col">
-
-        <h2>UIverse</h2>
-
-        <p>
-          Build faster with beautiful reusable UI components.
-        </p>
-
-      </div>
-
-      <div class="footer-col">
-
-        <h3>Components</h3>
-
-        <p>Buttons</p>
-        <p>Cards</p>
-        <p>Inputs</p>
-        <p>Span Elements</p>
-
-      </div>
-
-      <div class="footer-col">
-
-        <h3>Resources</h3>
-
-        <p>
-          <a href="#">
-            Documentation
-          </a>
-        </p>
-
-        <p>
-          <a href="#">
-            Tutorials
-          </a>
-        </p>
-
-        <p>
-          <a href="#">
-            Support
-          </a>
-        </p>
-
-      </div>
-
-      <div class="footer-col">
-
-        <h3>Follow Us</h3>
-
-        <p>
-          <i class="fa-brands fa-github"></i>
-          GitHub
-        </p>
-
-        <p>
-          <i class="fa-brands fa-twitter"></i>
-          Twitter
-        </p>
-
-        <p>
-          <i class="fa-brands fa-discord"></i>
-          Discord
-        </p>
-
-      </div>
-
-    </div>
-
-  </footer>
-
-  <!-- ========================================
-       SCRIPT
-  ========================================= -->
-  <script>
-
-    function toggleCode(id){
-
-      const block = document.getElementById(id);
-
-      if(block.style.display === "block"){
-
-        block.style.display = "none";
-
-      }else{
-
-        block.style.display = "block";
-
-      }
-
-    }
-
-    function copyCode(id,btn){
-
-      const text =
-        document.getElementById(id).innerText;
-
-      navigator.clipboard.writeText(text);
-
-      btn.innerHTML =
-        '<i class="fa-solid fa-check"></i> Copied';
-
-      setTimeout(() => {
-
-        btn.innerHTML =
-          '<i class="fa-regular fa-copy"></i> Copy';
-
-      },2000);
-
-    }
-
-    function toggleSidebar(){
-
-      document
-        .getElementById("sidebar")
-        .classList.toggle("show");
-
-      document
-        .querySelector(".sidebar-backdrop")
-        .classList.toggle("show");
-
-    }
-
-  </script>
-
-=======
+  
+  
 <!-- Scroll to Top -->
 <button id="scrollTopBtn" onclick="scrollToTop()">
   <i class="fa-solid fa-chevron-up"></i>
@@ -1882,6 +1160,5 @@ function copyTag(el, text) {
   }, { threshold: 0.08 });
   document.querySelectorAll('.component-card').forEach(el => observer.observe(el));
 </script>
->>>>>>> main
 </body>
 </html>


### PR DESCRIPTION

## Related Issue
Fix : duplicate footer in span page
Closes #807 

## Summary
This pull request improves the Span Page by removing duplicate components (navbar, sidebar, footer) and refining the overall UI layout for better clarity and consistency.

## Changes Made
 - Removed duplicate navbar, sidebar, and footer elements
- Streamlined layout structure for cleaner presentation
- Enhanced span styling for readability and accessibility

## Testing 
- Verified that navbar, sidebar, and footer appear only once
 - Confirmed improved readability in both light and dark themes

## Screenshots
<img width="1920" height="1080" alt="Screenshot (369)" src="https://github.com/user-attachments/assets/14230a16-58e4-4381-8e19-fc684e3687e8" />
<img width="1920" height="1080" alt="Screenshot (370)" src="https://github.com/user-attachments/assets/dd50aae4-0786-4774-b568-a549bd14e518" />


## Checklist
- [ ✅] Code follows project style
- [✅] Tested locally
- [✅ ] No unrelated changes included

### NSOC '26