### PR TITLE
fix: Inline HTML handlers / string templates increase XSS risk

### DIFF
--- a/Docs/chat/ui.js
+++ b/Docs/chat/ui.js
@@ -21,10 +21,16 @@ function sendMessage() {
     ":" +
     now.getMinutes().toString().padStart(2, "0");
 
-  messageDiv.innerHTML = `
-    <div class="message-content">${text}</div>
-    <span class="time">${time}</span>
-  `;
+  const msgContent = document.createElement('div');
+  msgContent.className = 'message-content';
+  msgContent.textContent = text;
+
+  const timeSpan = document.createElement('span');
+  timeSpan.className = 'time';
+  timeSpan.textContent = time;
+
+  messageDiv.appendChild(msgContent);
+  messageDiv.appendChild(timeSpan);
 
   chatBox.appendChild(messageDiv);
 
@@ -39,12 +45,16 @@ function sendMessage() {
 
     reply.classList.add("message", "received");
 
-    reply.innerHTML = `
-      <div class="message-content">
-        ✨ That's a great UI idea!
-      </div>
-      <span class="time">${time}</span>
-    `;
+    const replyContent = document.createElement('div');
+    replyContent.className = 'message-content';
+    replyContent.textContent = "✨ That's a great UI idea!";
+
+    const replyTime = document.createElement('span');
+    replyTime.className = 'time';
+    replyTime.textContent = time;
+
+    reply.appendChild(replyContent);
+    reply.appendChild(replyTime);
 
     chatBox.appendChild(reply);
 

--- a/MyCollection.html
+++ b/MyCollection.html
@@ -160,6 +160,7 @@
 
   <!-- UIverse Modular CSS Architecture -->
   <link rel="stylesheet" href="css/main.css">
+  <script src="js/core/sanitize.js"></script>
 </head>
 <body>
 
@@ -196,6 +197,16 @@ function showToast(message) {
   }, 2000);
 }
 
+function escapeHtml(str) {
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function removeFromCollection(id) {
   let items = JSON.parse(localStorage.getItem("collection")) || [];
   items = items.filter(item => item.id !== id);
@@ -219,14 +230,16 @@ function renderCollection() {
     return;
   }
 
+  // Build sanitized HTML for the collection grid. Use sanitizeHTML() to avoid XSS
   let html = '<div class="collection-grid">';
   
   items.forEach(item => {
+    const safeContent = (typeof sanitizeHTML === 'function') ? sanitizeHTML(item.content) : '';
     html += `
       <div class="collection-item">
-        <div class="item-title">${item.title}</div>
+        <div class="item-title">${escapeHtml(item.title)}</div>
         <div class="item-preview">
-          ${item.content}
+          ${safeContent}
         </div>
         <div class="item-actions">
           <button class="btn-copy" onclick="copyCode(${item.id})">Copy Code</button>
@@ -244,9 +257,7 @@ function copyCode(id) {
   let items = JSON.parse(localStorage.getItem("collection")) || [];
   let item = items.find(i => i.id === id);
   if (item) {
-    let tempDiv = document.createElement('div');
-    tempDiv.innerHTML = item.content;
-    let text = tempDiv.innerText;
+    // Copy raw component HTML to clipboard (avoid assigning user HTML into DOM)
     navigator.clipboard.writeText(item.content);
     
     // Find the button and update it

--- a/contributors.js
+++ b/contributors.js
@@ -130,13 +130,34 @@ function renderContributors(grid, contributors) {
   contributors.forEach((contributor, index) => {
     const card = document.createElement('div');
     card.className = 'contributor-card';
-    card.innerHTML = `
-      <img src="${contributor.avatar_url}" alt="${contributor.login}" class="contributor-avatar" />
-      <h3 class="contributor-name">${contributor.login}</h3>
-      <div class="contributor-role"><i class="fa-solid fa-code"></i> ${labels[index % labels.length]}</div>
-      <br>
-      <a href="${contributor.html_url}" target="_blank" class="github-link"><i class="fab fa-github"></i> View Profile</a>
-    `;
+
+    const img = document.createElement('img');
+    img.className = 'contributor-avatar';
+    img.src = contributor.avatar_url || '';
+    img.alt = contributor.login || '';
+
+    const name = document.createElement('h3');
+    name.className = 'contributor-name';
+    name.textContent = contributor.login || '';
+
+    const role = document.createElement('div');
+    role.className = 'contributor-role';
+    role.innerHTML = `<i class="fa-solid fa-code"></i> ${labels[index % labels.length]}`;
+
+    const br = document.createElement('br');
+
+    const link = document.createElement('a');
+    link.className = 'github-link';
+    link.href = contributor.html_url || '#';
+    link.target = '_blank';
+    link.innerHTML = '<i class="fab fa-github"></i> View Profile';
+
+    card.appendChild(img);
+    card.appendChild(name);
+    card.appendChild(role);
+    card.appendChild(br);
+    card.appendChild(link);
+
     grid.appendChild(card);
   });
 }

--- a/js/core/sanitize.js
+++ b/js/core/sanitize.js
@@ -1,0 +1,37 @@
+// Lightweight HTML sanitizer (DOMParser-based). Not a full replacement for DOMPurify
+// Removes <script>, <style>, <iframe>, <object>, <embed> and strips attributes starting with "on" and javascript: URIs.
+function sanitizeHTML(unsafeHtml) {
+  if (!unsafeHtml) return '';
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(unsafeHtml, 'text/html');
+
+  const forbiddenTags = ['script', 'style', 'iframe', 'object', 'embed'];
+  forbiddenTags.forEach(tag => {
+    doc.querySelectorAll(tag).forEach(el => el.remove());
+  });
+
+  // Remove event handlers and javascript: URIs
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, null, false);
+  const nodes = [];
+  while (walker.nextNode()) nodes.push(walker.currentNode);
+
+  nodes.forEach(node => {
+    // copy attributes to avoid modifying while iterating
+    const attrs = Array.from(node.attributes || []);
+    attrs.forEach(attr => {
+      const name = attr.name.toLowerCase();
+      const val = (attr.value || '').toLowerCase();
+      if (name.startsWith('on')) {
+        node.removeAttribute(attr.name);
+      } else if ((name === 'href' || name === 'src') && val.startsWith('javascript:')) {
+        node.removeAttribute(attr.name);
+      }
+    });
+  });
+
+  return doc.body.innerHTML || '';
+}
+
+// Expose for CommonJS/AMD if needed (keeps compatibility with simple script usage)
+if (typeof window !== 'undefined') window.sanitizeHTML = sanitizeHTML;
+module.exports = typeof module !== 'undefined' ? sanitizeHTML : undefined;

--- a/notesapp/app.js
+++ b/notesapp/app.js
@@ -16,16 +16,17 @@ function addNote(){
 
   noteCard.classList.add("note-card");
 
-  noteCard.innerHTML = `
-    <button class="delete-btn">×</button>
-    <p>${text}</p>
-  `;
+  const delBtn = document.createElement('button');
+  delBtn.className = 'delete-btn';
+  delBtn.textContent = '×';
 
-  const deleteBtn = noteCard.querySelector(".delete-btn");
+  const p = document.createElement('p');
+  p.textContent = text;
 
-  deleteBtn.addEventListener("click", () => {
-    noteCard.remove();
-  });
+  delBtn.addEventListener('click', () => noteCard.remove());
+
+  noteCard.appendChild(delBtn);
+  noteCard.appendChild(p);
 
   notesGrid.appendChild(noteCard);
 

--- a/taskmanager/task.js
+++ b/taskmanager/task.js
@@ -18,31 +18,32 @@ function addTask(){
 
   taskCard.classList.add("task-card");
 
-  taskCard.innerHTML = `
-    <span>${taskText}</span>
+  const span = document.createElement('span');
+  span.textContent = taskText;
 
-    <div class="task-buttons">
-      <button class="complete-btn">Done</button>
-      <button class="delete-btn">Delete</button>
-    </div>
-  `;
+  const buttonsDiv = document.createElement('div');
+  buttonsDiv.className = 'task-buttons';
 
-  const completeBtn = taskCard.querySelector(".complete-btn");
-  const deleteBtn = taskCard.querySelector(".delete-btn");
+  const completeBtn = document.createElement('button');
+  completeBtn.className = 'complete-btn';
+  completeBtn.textContent = 'Done';
 
-  completeBtn.addEventListener("click", () => {
+  const deleteBtn = document.createElement('button');
+  deleteBtn.className = 'delete-btn';
+  deleteBtn.textContent = 'Delete';
 
+  buttonsDiv.appendChild(completeBtn);
+  buttonsDiv.appendChild(deleteBtn);
+
+  completeBtn.addEventListener('click', () => {
     completeBtn.remove();
-
     completedTasks.appendChild(taskCard);
-
   });
 
-  deleteBtn.addEventListener("click", () => {
+  deleteBtn.addEventListener('click', () => taskCard.remove());
 
-    taskCard.remove();
-
-  });
+  taskCard.appendChild(span);
+  taskCard.appendChild(buttonsDiv);
 
   pendingTasks.appendChild(taskCard);
 

--- a/toasts.js
+++ b/toasts.js
@@ -93,7 +93,8 @@ const ToastWidget = {
 
     const toast = document.createElement("div");
     toast.className = `toast ${type}-toast`;
-    toast.innerHTML = message;
+    // Use textContent to avoid injecting untrusted HTML into toasts
+    toast.textContent = message;
     this._state.toastContainer.appendChild(toast);
 
     setTimeout(() => {

--- a/todo/todo.js
+++ b/todo/todo.js
@@ -16,26 +16,33 @@ function addTask(){
 
   li.classList.add("task-item");
 
-  li.innerHTML = `
-    <span>${taskText}</span>
+  const span = document.createElement('span');
+  span.textContent = taskText;
 
-    <div class="task-buttons">
-      <button class="complete-btn">Done</button>
-      <button class="delete-btn">Delete</button>
-    </div>
-  `;
+  const buttonsDiv = document.createElement('div');
+  buttonsDiv.className = 'task-buttons';
 
-  const completeBtn = li.querySelector(".complete-btn");
-  const deleteBtn = li.querySelector(".delete-btn");
-  const taskSpan = li.querySelector("span");
+  const completeBtn = document.createElement('button');
+  completeBtn.className = 'complete-btn';
+  completeBtn.textContent = 'Done';
 
-  completeBtn.addEventListener("click", () => {
-    taskSpan.classList.toggle("completed");
+  const deleteBtn = document.createElement('button');
+  deleteBtn.className = 'delete-btn';
+  deleteBtn.textContent = 'Delete';
+
+  buttonsDiv.appendChild(completeBtn);
+  buttonsDiv.appendChild(deleteBtn);
+
+  completeBtn.addEventListener('click', () => {
+    span.classList.toggle('completed');
   });
 
-  deleteBtn.addEventListener("click", () => {
+  deleteBtn.addEventListener('click', () => {
     li.remove();
   });
+
+  li.appendChild(span);
+  li.appendChild(buttonsDiv);
 
   taskList.appendChild(li);
 


### PR DESCRIPTION
Plan created and repo scanned for `innerHTML` risks; I patched high-risk cases and added a sanitizer.

**What I changed**
- **Patched toasts**: toasts.js — replaced `toast.innerHTML = message` → `toast.textContent = message`.
- **Added sanitizer**: sanitize.js — lightweight `sanitizeHTML()` (DOMParser-based) exposed globally.
- **Sanitized collection rendering**: MyCollection.html — include `sanitize.js`, sanitize `item.content` when inserting, escape titles, removed unsafe `tempDiv.innerHTML` copy path.
- **Safe contributor cards**: contributors.js — build DOM nodes and set attributes/textContent instead of templating external fields into `innerHTML`.
- **Chat UI safe**: ui.js — build message nodes and use `textContent` for user message text.
- **Notes app safe**: app.js — build nodes, use `textContent` for note text.
- **Todo safe**: todo.js — replaced `innerHTML` with DOM creation and `textContent`.
- **Task manager safe**: task.js — replaced `innerHTML` with DOM creation and `textContent`.
- Ran `node --check` on edited JS files (no syntax errors).

**High-priority remaining items (recommend immediate fixes)**
- MyCollection.html — already sanitized on render; confirm saved `item.content` sources are trusted.
- sandbox.js — uses `overlay.innerHTML = [...]` (review if it inserts user code).
- playground.js — preview insertion; ensure preview uses sanitized content when rendering user input.
- toast.js — currently uses internal map (safe), but if called with external data later, switch to sanitized insertion.
- Test harnesses (e.g., test-security-csp.html) — intentionally render HTML for tests; keep but isolate test-only code.

closes #1008