### PR TITLE
fix: sidebar_issue

### DIFF
--- a/home.css
+++ b/home.css
@@ -155,6 +155,11 @@ h1, h2, h3 {
   color: var(--accent);
 }
 
+.sidebar .brand-text,
+.sidebar .sidebar-nav span {
+  opacity: 1;
+}
+
 /* Sidebar backdrop (mobile) */
 .sidebar-backdrop {
   display: none;
@@ -1054,6 +1059,10 @@ body.dark-mode .feature-card:hover {
   }
 
   .sidebar.open {
+    transform: translateX(0);
+  }
+
+  body.sidebar-open .sidebar {
     transform: translateX(0);
   }
 

--- a/shared-page.css
+++ b/shared-page.css
@@ -5,6 +5,22 @@
    =================================================== */
 
 /* ============================================================
+   SIDEBAR FIX
+   Keep desktop sidebar expanded on component pages. A late rule
+   in style.css collapses labels unless `.open` is present.
+   ============================================================ */
+@media (min-width: 769px) {
+  .sidebar {
+    width: var(--sidebar-w);
+  }
+
+  .sidebar .brand-text,
+  .sidebar .sidebar-nav span {
+    opacity: 1;
+  }
+}
+
+/* ============================================================
    PAGE HERO
    ============================================================ */
 .page-hero {


### PR DESCRIPTION
Solves Issue No.: #890 

This PR fixes an issue where sidebar navigation labels were visible on the home page but hidden on other component pages like Buttons, Cards, and similar tabs. The problem was caused by a global collapsed-sidebar rule overriding the shared sidebar styles on non-home pages.

What Changed:
Updated home.css to keep sidebar label text visible by default.
Added a mobile open-state sidebar rule so the sidebar still slides in correctly on smaller screens.
Added a shared-page safeguard in shared-page.css to ensure component pages keep the expanded labeled sidebar on desktop.

Root Cause:-
A late rule in style.css was forcing:

.sidebar to a narrow collapsed width
.brand-text and .sidebar-nav span to opacity: 0
That behavior worked like a collapsed sidebar, but component pages were not explicitly reopening it on desktop, so only icons remained visible.

Files Changed:
home.css (line 158)
shared-page.css (line 8)

Impact::
Sidebar labels now remain visible across component pages.
Desktop navigation is consistent with the home page.
Mobile sidebar behavior remains intact.

Testing::
Verified the CSS fix logically against the current sidebar rules and page imports.
Full browser/runtime verification was not run in this workspace because dependencies are not installed.
