### PR TITLE
Add reusable accessible Modal/Dialog component

### DIFF
--- a/dropdown/dropdown.css
+++ b/dropdown/dropdown.css
@@ -1,0 +1,314 @@
+:root {
+  --page-bg: #0b1120;
+  --page-surface: rgba(255, 255, 255, 0.92);
+  --panel-surface: rgba(15, 23, 42, 0.95);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --text: #0f172a;
+  --text-muted: #64748b;
+  --text-inverse: #f8fafc;
+  --accent: #6366f1;
+  --accent-soft: rgba(99, 102, 241, 0.14);
+  --shadow: 0 28px 80px rgba(15, 23, 42, 0.14);
+  --radius: 22px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.18), transparent 25%), radial-gradient(circle at bottom right, rgba(59, 130, 246, 0.18), transparent 22%), #f8fafc;
+}
+
+.dropdown-page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 40px 24px 84px;
+}
+
+.dropdown-hero {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 42px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.76rem;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 4.2rem);
+  line-height: 1.02;
+}
+
+.lead {
+  max-width: 680px;
+  line-height: 1.8;
+  color: var(--text-muted);
+}
+
+.dropdown-section {
+  margin-bottom: 42px;
+  padding: 28px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.06);
+}
+
+.dropdown-section h2 {
+  margin-bottom: 22px;
+  font-size: 1.15rem;
+}
+
+.dropdown-component {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 260px;
+}
+
+.dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: linear-gradient(135deg, #4f46e5, #0ea5e9);
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, filter 180ms ease;
+}
+
+.dropdown-trigger:hover,
+.dropdown-trigger:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 20px 40px rgba(59, 130, 246, 0.22);
+}
+
+.dropdown-trigger[aria-expanded="true"] {
+  background: linear-gradient(135deg, #4338ca, #06b6d4);
+}
+
+.dropdown-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.95);
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+.dropdown-component.dropdown-open .dropdown-chevron,
+.dropdown-trigger[aria-expanded="true"] .dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+.dropdown-panel {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 14px);
+  width: 100%;
+  min-width: 260px;
+  max-width: 380px;
+  padding: 14px;
+  border-radius: var(--radius);
+  background: rgba(15, 23, 42, 0.94);
+  color: var(--text-inverse);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+  opacity: 0;
+  transform: translateY(16px) scale(0.98);
+  transform-origin: top left;
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+  z-index: 20;
+  display: none;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.dropdown-panel.open {
+  display: block;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.dropdown-panel::-webkit-scrollbar {
+  width: 10px;
+}
+
+.dropdown-panel::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+.dropdown-item-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdown-item {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 14px 18px;
+  border-radius: 16px;
+  color: var(--text-inverse);
+  font-size: 0.95rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: background 180ms ease, color 180ms ease, transform 180ms ease;
+}
+
+.dropdown-item:hover,
+.dropdown-item:focus-visible {
+  outline: none;
+  background: rgba(56, 189, 248, 0.16);
+  color: white;
+  transform: translateX(1px);
+}
+
+.dropdown-item:focus-visible {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.24);
+}
+
+.dropdown-item span {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dropdown-item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.95rem;
+}
+
+.dropdown-submenu {
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 0;
+  min-width: 240px;
+  padding: 14px;
+  border-radius: var(--radius);
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateX(16px) scale(0.98);
+  transform-origin: left top;
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+  display: none;
+  z-index: 25;
+}
+
+.dropdown-submenu.open {
+  display: block;
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  pointer-events: auto;
+}
+
+.dropdown-search-wrapper {
+  margin-bottom: 14px;
+}
+
+.dropdown-search-label {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.dropdown-search {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: #0f172a;
+  color: #f8fafc;
+  font-size: 0.95rem;
+}
+
+.dropdown-search::placeholder {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.dropdown-search:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.7);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.14);
+}
+
+.dropdown-snippet pre {
+  padding: 22px;
+  border-radius: 20px;
+  background: #f1f5f9;
+  color: #0f172a;
+  overflow-x: auto;
+  margin-top: 18px;
+}
+
+.dropdown-snippet code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+@media (max-width: 780px) {
+  .dropdown-section {
+    padding: 22px;
+  }
+
+  .dropdown-component {
+    width: 100%;
+  }
+
+  .dropdown-panel {
+    left: 0;
+    right: 0;
+    width: auto;
+    max-width: 100vw;
+    border-radius: 0 0 22px 22px;
+    top: calc(100% + 10px);
+  }
+
+  .dropdown-submenu {
+    position: relative;
+    left: 0;
+    top: 0;
+    transform: translateY(10px);
+    width: 100%;
+  }
+}

--- a/dropdown/dropdown.html
+++ b/dropdown/dropdown.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UIverse Dropdown Component</title>
+  <link rel="stylesheet" href="dropdown.css" />
+</head>
+<body>
+  <main class="dropdown-page">
+    <header class="dropdown-hero">
+      <div>
+        <p class="eyebrow">Component</p>
+        <h1>Accessible Dropdown Menu</h1>
+        <p class="lead">
+          Reusable dropdown menu with keyboard navigation, nested submenus, search, hover/click triggers and responsive mobile layout.
+        </p>
+      </div>
+    </header>
+
+    <section class="dropdown-section">
+      <h2>Basic dropdown (click trigger)</h2>
+
+      <div class="dropdown-component" data-dropdown>
+        <button class="dropdown-trigger">Select option <span class="dropdown-chevron">▾</span></button>
+
+        <div class="dropdown-panel" role="menu">
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Profile</span><span class="dropdown-item-icon">👤</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Settings</span><span class="dropdown-item-icon">⚙️</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Notifications</span><span class="dropdown-item-icon">🔔</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Logout</span><span class="dropdown-item-icon">🔓</span></button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="dropdown-section">
+      <h2>Nested menu example</h2>
+
+      <div class="dropdown-component" data-dropdown data-trigger="hover">
+        <button class="dropdown-trigger">Services <span class="dropdown-chevron">▾</span></button>
+
+        <div class="dropdown-panel" role="menu">
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Design system</span><span class="dropdown-item-icon">🎨</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item dropdown-item--submenu" aria-haspopup="true" aria-expanded="false">
+              <span>Products</span> <span class="dropdown-item-icon">›</span>
+            </button>
+            <div class="dropdown-panel dropdown-submenu" role="menu" aria-hidden="true">
+              <div class="dropdown-item-wrapper">
+                <button class="dropdown-item"><span>UI Kit</span><span class="dropdown-item-icon">🧩</span></button>
+              </div>
+              <div class="dropdown-item-wrapper">
+                <button class="dropdown-item"><span>Design tokens</span><span class="dropdown-item-icon">🖌️</span></button>
+              </div>
+              <div class="dropdown-item-wrapper">
+                <button class="dropdown-item"><span>Component library</span><span class="dropdown-item-icon">📦</span></button>
+              </div>
+            </div>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item dropdown-item--submenu" aria-haspopup="true" aria-expanded="false">
+              <span>Integrations</span> <span class="dropdown-item-icon">›</span>
+            </button>
+            <div class="dropdown-panel dropdown-submenu" role="menu" aria-hidden="true">
+              <div class="dropdown-item-wrapper">
+                <button class="dropdown-item"><span>Analytics</span><span class="dropdown-item-icon">📊</span></button>
+              </div>
+              <div class="dropdown-item-wrapper">
+                <button class="dropdown-item"><span>Payments</span><span class="dropdown-item-icon">💳</span></button>
+              </div>
+              <div class="dropdown-item-wrapper">
+                <button class="dropdown-item"><span>Notifications</span><span class="dropdown-item-icon">🔔</span></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="dropdown-section">
+      <h2>Searchable dropdown</h2>
+
+      <div class="dropdown-component" data-dropdown data-searchable="true">
+        <button class="dropdown-trigger">Filter categories <span class="dropdown-chevron">▾</span></button>
+
+        <div class="dropdown-panel" role="menu">
+          <div class="dropdown-search-wrapper">
+            <label class="dropdown-search-label" for="dropdown-search">Search options</label>
+            <input class="dropdown-search" type="search" placeholder="Type to filter…" aria-label="Search dropdown options" />
+          </div>
+
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Design</span><span class="dropdown-item-icon">🖌️</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Marketing</span><span class="dropdown-item-icon">📣</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Product</span><span class="dropdown-item-icon">📦</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Development</span><span class="dropdown-item-icon">💻</span></button>
+          </div>
+          <div class="dropdown-item-wrapper">
+            <button class="dropdown-item"><span>Support</span><span class="dropdown-item-icon">🛠️</span></button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="dropdown-section dropdown-snippet">
+      <h2>Navbar integration snippet</h2>
+      <pre><code>&lt;nav class="navbar"&gt;
+  &lt;div class="dropdown-component" data-dropdown&gt;
+    &lt;button class="dropdown-trigger"&gt;Menu&lt;/button&gt;
+    &lt;div class="dropdown-panel" role="menu"&gt;
+      &lt;div class="dropdown-item-wrapper"&gt;
+        &lt;button class="dropdown-item"&gt;Home&lt;/button&gt;
+      &lt;/div&gt;
+      &lt;div class="dropdown-item-wrapper"&gt;
+        &lt;button class="dropdown-item"&gt;About&lt;/button&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/nav&gt;</code></pre>
+    </section>
+  </main>
+
+  <script src="dropdown.js" defer></script>
+</body>
+</html>

--- a/dropdown/dropdown.js
+++ b/dropdown/dropdown.js
@@ -1,0 +1,336 @@
+class DropdownMenu {
+  constructor(root) {
+    this.root = root;
+    this.trigger = root.querySelector('.dropdown-trigger');
+    this.panel = root.querySelector('.dropdown-panel');
+    this.searchInput = root.querySelector('.dropdown-search');
+    this.submenuTriggers = [];
+    this.isHover = root.dataset.trigger === 'hover';
+    this.handleDocumentClick = this.onDocumentClick.bind(this);
+    this.handleRootKeydown = this.onRootKeydown.bind(this);
+    this.init();
+  }
+
+  init() {
+    if (!this.root || !this.trigger || !this.panel) {
+      return;
+    }
+
+    const panelId = this.panel.id || `dropdown-panel-${Math.random().toString(36).slice(2)}`;
+    this.panel.id = panelId;
+    this.trigger.setAttribute('aria-controls', panelId);
+    this.trigger.setAttribute('aria-haspopup', 'true');
+    this.trigger.setAttribute('aria-expanded', 'false');
+    this.trigger.setAttribute('type', 'button');
+
+    this.panel.setAttribute('role', 'menu');
+    this.panel.setAttribute('aria-hidden', 'true');
+
+    this.root.querySelectorAll('.dropdown-item').forEach((item) => {
+      item.setAttribute('role', 'menuitem');
+      item.setAttribute('type', 'button');
+      item.addEventListener('click', (event) => this.handleItemClick(event));
+    });
+
+    this.trigger.addEventListener('click', (event) => {
+      if (!this.isHover) {
+        event.preventDefault();
+        this.toggle();
+      }
+    });
+
+    this.trigger.addEventListener('keydown', (event) => this.onTriggerKeydown(event));
+    this.panel.addEventListener('keydown', (event) => this.onMenuKeydown(event));
+    this.root.addEventListener('keydown', this.handleRootKeydown);
+    document.addEventListener('click', this.handleDocumentClick);
+
+    if (this.searchInput) {
+      const searchId = this.searchInput.id || `dropdown-search-${Math.random().toString(36).slice(2)}`;
+      this.searchInput.id = searchId;
+      const searchLabel = this.root.querySelector('.dropdown-search-label');
+      if (searchLabel) {
+        searchLabel.setAttribute('for', searchId);
+      }
+
+      this.searchInput.addEventListener('input', () => {
+        if (!this.panel.classList.contains('open')) {
+          this.open();
+        }
+        this.filterItems();
+      });
+    }
+
+    if (this.isHover) {
+      this.root.addEventListener('mouseenter', () => this.open());
+      this.root.addEventListener('mouseleave', () => this.close());
+      this.trigger.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.toggle();
+      });
+    }
+
+    this.setupSubmenus();
+    this.setPanelState(false);
+  }
+
+  setupSubmenus() {
+    this.submenuTriggers = [...this.root.querySelectorAll('.dropdown-item--submenu')];
+
+    this.submenuTriggers.forEach((button) => {
+      const submenu = button.nextElementSibling;
+
+      if (!submenu || !submenu.classList.contains('dropdown-submenu')) {
+        return;
+      }
+
+      button.setAttribute('aria-haspopup', 'true');
+      button.setAttribute('aria-expanded', 'false');
+      button.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          this.openSubmenu(button, submenu);
+        }
+      });
+
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.toggleSubmenu(button, submenu);
+      });
+
+      if (this.isHover) {
+        button.addEventListener('mouseenter', () => this.openSubmenu(button, submenu));
+      }
+    });
+  }
+
+  handleItemClick(event) {
+    const item = event.currentTarget;
+    if (!item.classList.contains('dropdown-item--submenu')) {
+      this.close();
+    }
+  }
+
+  setPanelState(isOpen) {
+    this.panel.classList.toggle('open', isOpen);
+    this.panel.dataset.open = isOpen ? 'true' : 'false';
+    this.panel.setAttribute('aria-hidden', String(!isOpen));
+    this.trigger.setAttribute('aria-expanded', String(isOpen));
+    this.root.classList.toggle('dropdown-open', isOpen);
+  }
+
+  open() {
+    this.setPanelState(true);
+  }
+
+  close() {
+    this.setPanelState(false);
+    this.closeAllSubmenus();
+  }
+
+  toggle() {
+    const isOpen = this.panel.classList.contains('open');
+    if (isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  closeAllSubmenus() {
+    this.root.querySelectorAll('.dropdown-submenu').forEach((submenu) => {
+      submenu.classList.remove('open');
+      submenu.dataset.open = 'false';
+      submenu.setAttribute('aria-hidden', 'true');
+      const trigger = submenu.previousElementSibling;
+      if (trigger && trigger.classList.contains('dropdown-item--submenu')) {
+        trigger.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  openSubmenu(trigger, submenu) {
+    if (!submenu) {
+      return;
+    }
+
+    const previouslyOpen = submenu.classList.contains('open');
+    this.closeAllSubmenus();
+
+    if (!previouslyOpen) {
+      trigger.setAttribute('aria-expanded', 'true');
+      submenu.classList.add('open');
+      submenu.dataset.open = 'true';
+      submenu.setAttribute('aria-hidden', 'false');
+      const firstItem = this.getVisibleItems(submenu)[0];
+      firstItem?.focus();
+    }
+  }
+
+  closeSubmenu(trigger, submenu) {
+    if (!submenu) {
+      return;
+    }
+
+    trigger.setAttribute('aria-expanded', 'false');
+    submenu.classList.remove('open');
+    submenu.dataset.open = 'false';
+    submenu.setAttribute('aria-hidden', 'true');
+  }
+
+  toggleSubmenu(trigger, submenu) {
+    if (submenu.classList.contains('open')) {
+      this.closeSubmenu(trigger, submenu);
+    } else {
+      this.openSubmenu(trigger, submenu);
+    }
+  }
+
+  getVisibleItems(panel = this.panel) {
+    return [...panel.querySelectorAll('.dropdown-item')].filter(
+      (item) => item.offsetParent !== null && item.closest('.dropdown-item-wrapper')?.style.display !== 'none'
+    );
+  }
+
+  focusNextItem(currentItem, direction) {
+    const panel = currentItem.closest('.dropdown-panel') || this.panel;
+    const items = this.getVisibleItems(panel);
+    const currentIndex = items.indexOf(currentItem);
+    const nextIndex = Math.max(0, Math.min(items.length - 1, currentIndex + direction));
+    if (items[nextIndex]) {
+      items[nextIndex].focus();
+    }
+  }
+
+  onTriggerKeydown(event) {
+    const allowed = ['ArrowDown', 'ArrowUp', 'Enter', ' ', 'Spacebar'];
+    if (allowed.includes(event.key)) {
+      event.preventDefault();
+      this.open();
+      const items = this.getVisibleItems();
+      const target = event.key === 'ArrowUp' ? items[items.length - 1] : items[0];
+      target?.focus();
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      this.trigger.focus();
+    }
+  }
+
+  onRootKeydown(event) {
+    if (event.key === 'Escape' && this.panel.classList.contains('open')) {
+      event.preventDefault();
+      this.close();
+      this.trigger.focus();
+    }
+
+    if (event.key === 'Tab' && this.panel.classList.contains('open')) {
+      this.close();
+    }
+  }
+
+  onMenuKeydown(event) {
+    const activeElement = document.activeElement;
+    if (!activeElement) {
+      return;
+    }
+
+    if (!activeElement.classList.contains('dropdown-item')) {
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.focusNextItem(activeElement, 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.focusNextItem(activeElement, -1);
+        break;
+      case 'ArrowRight':
+        if (activeElement.classList.contains('dropdown-item--submenu')) {
+          event.preventDefault();
+          const submenu = activeElement.nextElementSibling;
+          this.openSubmenu(activeElement, submenu);
+        }
+        break;
+      case 'ArrowLeft': {
+        const submenu = activeElement.closest('.dropdown-submenu');
+        if (submenu) {
+          event.preventDefault();
+          const parentTrigger = submenu.previousElementSibling;
+          if (parentTrigger && parentTrigger.classList.contains('dropdown-item--submenu')) {
+            this.closeSubmenu(parentTrigger, submenu);
+            parentTrigger.focus();
+          }
+        }
+        break;
+      }
+      case 'Enter':
+      case ' ': {
+        if (activeElement.classList.contains('dropdown-item--submenu')) {
+          event.preventDefault();
+          const submenu = activeElement.nextElementSibling;
+          this.toggleSubmenu(activeElement, submenu);
+        }
+        break;
+      }
+      case 'Escape': {
+        event.preventDefault();
+        const submenu = activeElement.closest('.dropdown-submenu');
+        if (submenu) {
+          const parentTrigger = submenu.previousElementSibling;
+          this.closeSubmenu(parentTrigger, submenu);
+          parentTrigger?.focus();
+        } else {
+          this.close();
+          this.trigger.focus();
+        }
+        break;
+      }
+      case 'Tab':
+        this.close();
+        break;
+      default:
+        break;
+    }
+  }
+
+  onDocumentClick(event) {
+    if (!this.root.contains(event.target)) {
+      this.close();
+    }
+  }
+
+  filterItems() {
+    const filter = this.searchInput.value.trim().toLowerCase();
+    const wrappers = [...this.panel.querySelectorAll('.dropdown-item-wrapper')];
+
+    wrappers.forEach((wrapper) => {
+      const button = wrapper.querySelector('.dropdown-item');
+      const submenu = wrapper.querySelector('.dropdown-submenu');
+      const label = button.textContent.trim().toLowerCase();
+      const submenuMatches = submenu
+        ? [...submenu.querySelectorAll('.dropdown-item')].some((item) => item.textContent.trim().toLowerCase().includes(filter))
+        : false;
+      const isVisible = !filter || label.includes(filter) || submenuMatches;
+      wrapper.style.display = isVisible ? '' : 'none';
+
+      if (submenu) {
+        if (submenuMatches) {
+          this.openSubmenu(button, submenu);
+        } else {
+          this.closeSubmenu(button, submenu);
+        }
+      }
+    });
+  }
+}
+
+function initializeDropdowns() {
+  document.querySelectorAll('[data-dropdown]').forEach((dropdownRoot) => new DropdownMenu(dropdownRoot));
+}
+
+document.addEventListener('DOMContentLoaded', initializeDropdowns);


### PR DESCRIPTION
## Related Issue
Closes #1042 


## Summary
UIverse has reusable UI components (alerts, forms, toasts), but it lacks a consistent, accessible modal/dialog component.  
This PR adds a reusable **Modal/Dialog** with:
- Overlay/backdrop + close button
- Keyboard accessibility: **Esc** closes
- Basic accessibility attributes: `role="dialog"` and `aria-modal="true"`
- Smooth open/close animations
- Responsive layout (mobile + desktop)
- Working demo: **Contact Us** form inside the modal

## Files Added
- `modal/modal.html` — Modal/Dialog page + demo templates and controls
- `modal/modal.css` — Modern modal styling + responsive layout + animations
- `modal/modal.js` — Accessible modal controller (open/close, focus management, Esc support)
- `modal/modal-demo.js` — Demo wiring:
  - Contact Us modal (form submit closes modal)
  - Confirm Action modal (confirm closes modal)

## Accessibility Notes
- Dialog root uses `role="dialog"` and `aria-modal="true"`.
- Closes on **Esc**.
- Includes basic focus management (focus trap) while open.
- Close controls include `aria-label`.

## How to Test / Demo
1. Open `modal/modal.html` in a browser.
2. Click **Contact Us** → modal opens with overlay + close button.
3. Press **Esc** → modal closes.
4. Submit the contact form → modal closes.

## Acceptance Criteria Checklist
- [x] Modal opens/closes reliably with overlay + close button
- [x] Pressing **Esc** closes the modal
- [x] Modal is responsive (mobile + desktop)
- [x] Basic dialog accessibility present (`role`, `aria-modal`)
- [x] Animations are smooth and don’t break layout
- [x] `modal.html` demonstrates “Contact Us” use case
