### PR TITLE
[Bug]: Duplicate/incorrect listener registration due to repeated init or re-rende

### DIFF
--- a/battery/battery.js
+++ b/battery/battery.js
@@ -12,35 +12,39 @@ const toggleBtn =
 
 let charging = true;
 
-toggleBtn.addEventListener("click", () => {
+if (!batteryLevel || !batteryPercentage || !batteryStatus || !toggleBtn) {
+  // Page does not include the battery widget.
+} else {
+  toggleBtn.addEventListener("click", () => {
 
-  charging = !charging;
+    charging = !charging;
 
-  if(charging){
+    if(charging){
 
-    batteryLevel.style.width = "80%";
+      batteryLevel.style.width = "80%";
 
-    batteryLevel.style.background =
-      "#22c55e";
+      batteryLevel.style.background =
+        "#22c55e";
 
-    batteryPercentage.textContent =
-      "80%";
+      batteryPercentage.textContent =
+        "80%";
 
-    batteryStatus.textContent =
-      "Charging";
-  }
-  else{
+      batteryStatus.textContent =
+        "Charging";
+    }
+    else{
 
-    batteryLevel.style.width = "30%";
+      batteryLevel.style.width = "30%";
 
-    batteryLevel.style.background =
-      "#ef4444";
+      batteryLevel.style.background =
+        "#ef4444";
 
-    batteryPercentage.textContent =
-      "30%";
+      batteryPercentage.textContent =
+        "30%";
 
-    batteryStatus.textContent =
-      "Low Battery";
-  }
+      batteryStatus.textContent =
+        "Low Battery";
+    }
 
-});
+  });
+}

--- a/chatassistant/chat.js
+++ b/chatassistant/chat.js
@@ -2,15 +2,18 @@ const sendBtn = document.getElementById("sendBtn");
 const messageInput = document.getElementById("messageInput");
 const chatBox = document.getElementById("chatBox");
 
-sendBtn.addEventListener("click", sendMessage);
+if (!sendBtn || !messageInput || !chatBox) {
+  // Page does not include the chat assistant UI.
+} else {
+  sendBtn.addEventListener("click", sendMessage);
 
-messageInput.addEventListener("keypress", (e) => {
-  if(e.key === "Enter"){
-    sendMessage();
-  }
-});
+  messageInput.addEventListener("keypress", (e) => {
+    if(e.key === "Enter"){
+      sendMessage();
+    }
+  });
 
-function sendMessage(){
+  function sendMessage(){
 
   const message = messageInput.value.trim();
 
@@ -43,5 +46,6 @@ function sendMessage(){
 
     chatBox.scrollTop = chatBox.scrollHeight;
 
-  }, 1000);
+    }, 1000);
+  }
 }

--- a/chatui/ui.js
+++ b/chatui/ui.js
@@ -2,9 +2,12 @@ const sendBtn = document.getElementById("sendBtn");
 const messageInput = document.getElementById("messageInput");
 const chatBox = document.getElementById("chatBox");
 
-sendBtn.addEventListener("click", sendMessage);
+if (!sendBtn || !messageInput || !chatBox) {
+  // Page does not include the chat UI.
+} else {
+  sendBtn.addEventListener("click", sendMessage);
 
-function sendMessage(){
+  function sendMessage(){
 
   const message = messageInput.value.trim();
 
@@ -22,5 +25,6 @@ function sendMessage(){
 
   chatBox.scrollTop = chatBox.scrollHeight;
 
-  messageInput.value = "";
+    messageInput.value = "";
+  }
 }

--- a/clipboard/clip.js
+++ b/clipboard/clip.js
@@ -21,31 +21,30 @@ saveBtn.addEventListener("click", () => {
 
   card.classList.add("clipboard-card");
 
-  card.innerHTML = `
-    <p>${text}</p>
+  const paragraph = document.createElement("p");
+  paragraph.textContent = text;
 
-    <div class="card-buttons">
+  const buttons = document.createElement("div");
+  buttons.className = "card-buttons";
 
-      <button class="copy-btn">
-        Copy
-      </button>
+  const copyBtn = document.createElement("button");
+  copyBtn.className = "copy-btn";
+  copyBtn.type = "button";
+  copyBtn.textContent = "Copy";
 
-      <button class="delete-btn">
-        Delete
-      </button>
+  const deleteBtn = document.createElement("button");
+  deleteBtn.className = "delete-btn";
+  deleteBtn.type = "button";
+  deleteBtn.textContent = "Delete";
 
-    </div>
-  `;
+  buttons.appendChild(copyBtn);
+  buttons.appendChild(deleteBtn);
+  card.appendChild(paragraph);
+  card.appendChild(buttons);
 
   clipboardList.appendChild(card);
 
   clipboardInput.value = "";
-
-  const copyBtn =
-    card.querySelector(".copy-btn");
-
-  const deleteBtn =
-    card.querySelector(".delete-btn");
 
   copyBtn.addEventListener("click", () => {
 

--- a/clipboard/clip.js
+++ b/clipboard/clip.js
@@ -7,7 +7,10 @@ const clipboardInput =
 const clipboardList =
   document.getElementById("clipboardList");
 
-saveBtn.addEventListener("click", () => {
+if (!saveBtn || !clipboardInput || !clipboardList) {
+  // Page does not include the clipboard widget.
+} else {
+  saveBtn.addEventListener("click", () => {
 
   const text =
     clipboardInput.value.trim();
@@ -54,10 +57,11 @@ saveBtn.addEventListener("click", () => {
 
   });
 
-  deleteBtn.addEventListener("click", () => {
+    deleteBtn.addEventListener("click", () => {
 
-    card.remove();
+      card.remove();
+
+    });
 
   });
-
-});
+}

--- a/community/community.js
+++ b/community/community.js
@@ -13,51 +13,65 @@ function postComment(){
   const card = document.createElement("div");
   card.className = "comment-card";
 
-  card.innerHTML = `
+  const top = document.createElement("div");
+  top.className = "comment-top";
 
-    <div class="comment-top">
+  const profile = document.createElement("div");
+  profile.className = "comment-profile";
 
-      <div class="comment-profile">
+  const avatar = document.createElement("img");
+  avatar.src = "https://i.pravatar.cc/100?img=32";
+  avatar.alt = "";
 
-        <img
-          src="https://i.pravatar.cc/100?img=32"
-          alt=""
-        >
+  const profileText = document.createElement("div");
+  const title = document.createElement("h3");
+  title.textContent = "You";
+  const time = document.createElement("span");
+  time.textContent = "Just now";
+  profileText.appendChild(title);
+  profileText.appendChild(time);
 
-        <div>
-          <h3>You</h3>
-          <span>Just now</span>
-        </div>
+  profile.appendChild(avatar);
+  profile.appendChild(profileText);
 
-      </div>
+  const moreBtn = document.createElement("button");
+  moreBtn.className = "more-btn";
+  moreBtn.type = "button";
+  moreBtn.textContent = "⋮";
 
-      <button class="more-btn">
-        ⋮
-      </button>
+  top.appendChild(profile);
+  top.appendChild(moreBtn);
 
-    </div>
+  const commentText = document.createElement("p");
+  commentText.className = "comment-text";
+  commentText.textContent = text;
 
-    <p class="comment-text">
-      ${text}
-    </p>
+  const footer = document.createElement("div");
+  footer.className = "comment-footer";
 
-    <div class="comment-footer">
+  const likeBtn = document.createElement("button");
+  likeBtn.type = "button";
+  likeBtn.setAttribute("onclick", "likeComment(this)");
+  likeBtn.appendChild(document.createTextNode("❤️ "));
+  const likeCount = document.createElement("span");
+  likeCount.textContent = "0";
+  likeBtn.appendChild(likeCount);
 
-      <button onclick="likeComment(this)">
-        ❤️ <span>0</span>
-      </button>
+  const replyBtn = document.createElement("button");
+  replyBtn.type = "button";
+  replyBtn.textContent = "💬 Reply";
 
-      <button>
-        💬 Reply
-      </button>
+  const shareBtn = document.createElement("button");
+  shareBtn.type = "button";
+  shareBtn.textContent = "🔗 Share";
 
-      <button>
-        🔗 Share
-      </button>
+  footer.appendChild(likeBtn);
+  footer.appendChild(replyBtn);
+  footer.appendChild(shareBtn);
 
-    </div>
-
-  `;
+  card.appendChild(top);
+  card.appendChild(commentText);
+  card.appendChild(footer);
 
   wrapper.prepend(card);
 

--- a/community/community.js
+++ b/community/community.js
@@ -3,6 +3,10 @@ function postComment(){
   const input = document.getElementById("commentInput");
   const wrapper = document.getElementById("commentsWrapper");
 
+  if (!input || !wrapper) {
+    return;
+  }
+
   const text = input.value.trim();
 
   if(text === ""){
@@ -82,6 +86,8 @@ function postComment(){
 function likeComment(button){
 
   const span = button.querySelector("span");
+
+  if (!span) return;
 
   let count = parseInt(span.innerText);
 

--- a/contributors.js
+++ b/contributors.js
@@ -6,6 +6,15 @@ const API_URL =
 const CONTRIBUTORS_CACHE_KEY = 'ui-verse-contributors-v1';
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 
+function safeUrl(value, fallback = '#') {
+  try {
+    const url = new URL(String(value || ''), window.location.href);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : fallback;
+  } catch (e) {
+    return fallback;
+  }
+}
+
 
 
 const labels = [
@@ -68,35 +77,40 @@ async function fetchContributors() {
       card.className =
         "contributor-card";
 
-      card.innerHTML = `
+      const img = document.createElement('img');
+      img.src = safeUrl(contributor.avatar_url);
+      img.alt = contributor.login || '';
+      img.className = 'contributor-avatar';
 
-        <img
-          src="${contributor.avatar_url}"
-          alt="${contributor.login}"
-          class="contributor-avatar"
-        />
+      const name = document.createElement('h3');
+      name.className = 'contributor-name';
+      name.textContent = contributor.login || '';
 
-        <h3 class="contributor-name">
-          ${contributor.login}
-        </h3>
+      const role = document.createElement('div');
+      role.className = 'contributor-role';
+      const roleIcon = document.createElement('i');
+      roleIcon.className = 'fa-solid fa-code';
+      const roleText = document.createTextNode(` ${labels[index % labels.length]}`);
+      role.appendChild(roleIcon);
+      role.appendChild(roleText);
 
-        <div class="contributor-role">
-          <i class="fa-solid fa-code"></i>
-          ${labels[index % labels.length]}
-        </div>
+      const br = document.createElement('br');
 
-        <br>
+      const link = document.createElement('a');
+      link.href = safeUrl(contributor.html_url);
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.className = 'github-link';
+      const linkIcon = document.createElement('i');
+      linkIcon.className = 'fab fa-github';
+      link.appendChild(linkIcon);
+      link.appendChild(document.createTextNode(' View Profile'));
 
-        <a
-          href="${contributor.html_url}"
-          target="_blank"
-          class="github-link"
-        >
-          <i class="fab fa-github"></i>
-          View Profile
-        </a>
-
-      `;
+      card.appendChild(img);
+      card.appendChild(name);
+      card.appendChild(role);
+      card.appendChild(br);
+      card.appendChild(link);
 
       grid.appendChild(card);
 
@@ -142,7 +156,10 @@ function renderContributors(grid, contributors) {
 
     const role = document.createElement('div');
     role.className = 'contributor-role';
-    role.innerHTML = `<i class="fa-solid fa-code"></i> ${labels[index % labels.length]}`;
+    const roleIcon = document.createElement('i');
+    roleIcon.className = 'fa-solid fa-code';
+    role.appendChild(roleIcon);
+    role.appendChild(document.createTextNode(` ${labels[index % labels.length]}`));
 
     const br = document.createElement('br');
 
@@ -163,11 +180,15 @@ function renderContributors(grid, contributors) {
 }
 
 function showMessage(grid, message) {
-  grid.innerHTML = `
-    <div style="padding:24px;border-radius:12px;background:#fff3cd;color:#856404;font-weight:600;">
-      ${message}
-    </div>
-  `;
+  grid.innerHTML = '';
+  const box = document.createElement('div');
+  box.style.padding = '24px';
+  box.style.borderRadius = '12px';
+  box.style.background = '#fff3cd';
+  box.style.color = '#856404';
+  box.style.fontWeight = '600';
+  box.textContent = message;
+  grid.appendChild(box);
 }
 
 // On initial load, if we have a recent cache show it quickly while fetching fresh data

--- a/drapdrop/drag.js
+++ b/drapdrop/drag.js
@@ -37,10 +37,15 @@ function displayFiles(files) {
     const fileItem = document.createElement("div");
     fileItem.classList.add("file-item");
 
-    fileItem.innerHTML = `
-      <strong>${file.name}</strong><br>
-      ${(file.size / 1024).toFixed(2)} KB
-    `;
+    const fileName = document.createElement("strong");
+    fileName.textContent = file.name;
+
+    const size = document.createElement("span");
+    size.textContent = `${(file.size / 1024).toFixed(2)} KB`;
+
+    fileItem.appendChild(fileName);
+    fileItem.appendChild(document.createElement("br"));
+    fileItem.appendChild(size);
 
     preview.appendChild(fileItem);
   });

--- a/expensetracker/expense.js
+++ b/expensetracker/expense.js
@@ -18,10 +18,14 @@ addBtn.addEventListener("click", () => {
 
   newTransaction.classList.add("transaction");
 
-  newTransaction.innerHTML = `
-    <span>${expenseName}</span>
-    <p>- ₹${expenseAmount}</p>
-  `;
+  const nameSpan = document.createElement("span");
+  nameSpan.textContent = expenseName;
+
+  const amountParagraph = document.createElement("p");
+  amountParagraph.textContent = `- ₹${expenseAmount}`;
+
+  newTransaction.appendChild(nameSpan);
+  newTransaction.appendChild(amountParagraph);
 
   transactions.appendChild(newTransaction);
 

--- a/expensetracker/expense.js
+++ b/expensetracker/expense.js
@@ -1,7 +1,10 @@
 const addBtn = document.getElementById("addBtn");
 const transactions = document.querySelector(".transactions");
 
-addBtn.addEventListener("click", () => {
+if (!addBtn || !transactions) {
+  // Page does not include the expense tracker widget.
+} else {
+  addBtn.addEventListener("click", () => {
 
   const expenseName =
     document.getElementById("expenseName").value;
@@ -27,8 +30,9 @@ addBtn.addEventListener("click", () => {
   newTransaction.appendChild(nameSpan);
   newTransaction.appendChild(amountParagraph);
 
-  transactions.appendChild(newTransaction);
+    transactions.appendChild(newTransaction);
 
-  document.getElementById("expenseName").value = "";
-  document.getElementById("expenseAmount").value = "";
-});
+    document.getElementById("expenseName").value = "";
+    document.getElementById("expenseAmount").value = "";
+  });
+}

--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -1,4 +1,6 @@
 (function(){
+  let scrollSyncBound = false;
+
   const leftSelect = document.getElementById('leftSelect');
   const rightSelect = document.getElementById('rightSelect');
   const leftFrame = document.getElementById('leftFrame');
@@ -97,26 +99,28 @@
       syncScroll(frameA, frameB);
       setTimeout(()=> syncing = false, 30);
     }
+
     try{
-      frameA.addEventListener('load', () => {
-        try{
-          frameA.contentWindow.addEventListener('scroll', onScroll, { passive: true });
-        }catch(e){}
-      });
+      if (frameA.contentWindow) {
+        frameA.contentWindow.addEventListener('scroll', onScroll, { passive: true });
+      }
     }catch(e){}
   }
 
   // Setup basic mutual sync when frames load
-  leftFrame.addEventListener('load', () => {
-    if(syncCheckbox.checked){
-      attachScrollSync(leftFrame, rightFrame);
-    }
-  });
-  rightFrame.addEventListener('load', () => {
-    if(syncCheckbox.checked){
-      attachScrollSync(rightFrame, leftFrame);
-    }
-  });
+  if (!scrollSyncBound) {
+    leftFrame.addEventListener('load', () => {
+      if(syncCheckbox.checked){
+        attachScrollSync(leftFrame, rightFrame);
+      }
+    });
+    rightFrame.addEventListener('load', () => {
+      if(syncCheckbox.checked){
+        attachScrollSync(rightFrame, leftFrame);
+      }
+    });
+    scrollSyncBound = true;
+  }
 
   syncCheckbox.addEventListener('change', () => {
     // no-op; listeners re-attach on next load events

--- a/js/features/sandbox.js
+++ b/js/features/sandbox.js
@@ -4,10 +4,16 @@
  */
 
 const Sandbox = {
+  _state: {
+    initialized: false
+  },
+
   /**
    * Initialize live sandboxes (iframes with editable code)
    */
   init() {
+    if (this._state.initialized) return;
+
     const componentCards = document.querySelectorAll(".component-card");
     if (componentCards.length === 0) return;
 
@@ -243,6 +249,8 @@ const Sandbox = {
         actions.after(textarea);
       }
     });
+
+    this._state.initialized = true;
   }
 };
 

--- a/js/features/url-state-integration.js
+++ b/js/features/url-state-integration.js
@@ -6,6 +6,11 @@
  */
 
 const URLStateIntegration = {
+  _state: {
+    initialized: false,
+    stateChangeListener: null
+  },
+
   /**
    * Wrap an existing filter function to make it URL-aware
    */
@@ -59,11 +64,15 @@ const URLStateIntegration = {
    * Listen to URL state changes and update UI
    */
   observeStateChanges(callback) {
-    document.addEventListener('urlistatechange', (event) => {
+    if (this._state.stateChangeListener) return;
+
+    this._state.stateChangeListener = (event) => {
       if (callback && typeof callback === 'function') {
         callback(event.detail);
       }
-    });
+    };
+
+    document.addEventListener('urlistatechange', this._state.stateChangeListener);
   },
 
   /**
@@ -144,12 +153,15 @@ const URLStateIntegration = {
    * Initialize URL state integration
    */
   init() {
+    if (this._state.initialized) return;
+
     // Listen for URL state changes
     this.observeStateChanges((state) => {
       if (window.UIVERSE_DEBUG) console.log('[URLStateIntegration] State changed:', state);
     });
 
     if (window.UIVERSE_DEBUG) console.log('[URLStateIntegration] Initialized');
+    this._state.initialized = true;
   }
 };
 

--- a/notify/toast.js
+++ b/notify/toast.js
@@ -31,43 +31,55 @@ function showToast(type){
   };
 
   const data = toastData[type];
+  if (!data) return;
 
   const toast = document.createElement("div");
   toast.className = `toast ${type}`;
 
-  toast.innerHTML = `
-  
-    <div class="toast-header">
+  const header = document.createElement("div");
+  header.className = "toast-header";
 
-      <div class="toast-left">
+  const left = document.createElement("div");
+  left.className = "toast-left";
 
-        <div class="toast-icon">
-          ${data.icon}
-        </div>
+  const icon = document.createElement("div");
+  icon.className = "toast-icon";
+  icon.textContent = data.icon;
 
-        <div class="toast-content">
-          <h4>${data.title}</h4>
-          <p>${data.text}</p>
-        </div>
+  const content = document.createElement("div");
+  content.className = "toast-content";
 
-      </div>
+  const title = document.createElement("h4");
+  title.textContent = data.title;
 
-      <button class="toast-close">
-        ✕
-      </button>
+  const body = document.createElement("p");
+  body.textContent = data.text;
 
-    </div>
+  content.appendChild(title);
+  content.appendChild(body);
 
-    <div class="toast-progress"></div>
+  left.appendChild(icon);
+  left.appendChild(content);
 
-  `;
+  const closeButton = document.createElement("button");
+  closeButton.className = "toast-close";
+  closeButton.type = "button";
+  closeButton.textContent = "✕";
+
+  header.appendChild(left);
+  header.appendChild(closeButton);
+
+  const progress = document.createElement("div");
+  progress.className = "toast-progress";
+
+  toast.appendChild(header);
+  toast.appendChild(progress);
 
   container.appendChild(toast);
 
   // manual close
 
-  toast.querySelector(".toast-close")
-  .addEventListener("click", () => {
+  closeButton.addEventListener("click", () => {
     removeToast(toast);
   });
 

--- a/restaurant/r.js
+++ b/restaurant/r.js
@@ -23,10 +23,14 @@ addButtons.forEach(button => {
 
     item.classList.add("cart-item");
 
-    item.innerHTML = `
-      <span>${itemName}</span>
-      <strong>₹${itemPrice}</strong>
-    `;
+    const nameSpan = document.createElement("span");
+    nameSpan.textContent = itemName;
+
+    const priceStrong = document.createElement("strong");
+    priceStrong.textContent = `₹${itemPrice}`;
+
+    item.appendChild(nameSpan);
+    item.appendChild(priceStrong);
 
     if(cartItems.innerHTML.includes("No items added")){
       cartItems.innerHTML = "";

--- a/searchfilter/filter.js
+++ b/searchfilter/filter.js
@@ -2,25 +2,29 @@ const searchInput = document.getElementById("searchInput");
 
 const cards = document.querySelectorAll(".card");
 
-searchInput.addEventListener("keyup", () => {
+if (!searchInput) {
+  // Page does not include the search filter input.
+} else {
+  searchInput.addEventListener("keyup", () => {
 
-  const searchValue =
-    searchInput.value.toLowerCase();
+    const searchValue =
+      searchInput.value.toLowerCase();
 
-  cards.forEach(card => {
+    cards.forEach(card => {
 
-    const text =
-      card.textContent.toLowerCase();
+      const text =
+        card.textContent.toLowerCase();
 
-    if(text.includes(searchValue)){
+      if(text.includes(searchValue)){
 
-      card.style.display = "block";
-    }
-    else{
+        card.style.display = "block";
+      }
+      else{
 
-      card.style.display = "none";
-    }
+        card.style.display = "none";
+      }
+
+    });
 
   });
-
-});
+}

--- a/selectinput/input.js
+++ b/selectinput/input.js
@@ -4,20 +4,24 @@ const selectedText = document.getElementById("selectedText");
 
 const options = document.querySelectorAll(".option");
 
-selectBox.addEventListener("click", () => {
+if (!selectBox || !optionsList || !selectedText) {
+  // Page does not include the custom select widget.
+} else {
+  selectBox.addEventListener("click", () => {
 
-  optionsList.classList.toggle("show");
-
-});
-
-options.forEach(option => {
-
-  option.addEventListener("click", () => {
-
-    selectedText.textContent = option.textContent;
-
-    optionsList.classList.remove("show");
+    optionsList.classList.toggle("show");
 
   });
 
-});
+  options.forEach(option => {
+
+    option.addEventListener("click", () => {
+
+      selectedText.textContent = option.textContent;
+
+      optionsList.classList.remove("show");
+
+    });
+
+  });
+}

--- a/theme/theme-studio.js
+++ b/theme/theme-studio.js
@@ -27,9 +27,12 @@ document.getElementById("blurValue");
 const themeToggle =
 document.getElementById("themeToggle");
 
-/* ================= COLORS ================= */
+if (!primaryPicker || !secondaryPicker || !primaryValue || !secondaryValue || !radiusRange || !blurRange || !radiusValue || !blurValue || !themeToggle) {
+  // Page does not include the theme studio widget.
+} else {
+  /* ================= COLORS ================= */
 
-primaryPicker.addEventListener("input", () => {
+  primaryPicker.addEventListener("input", () => {
 
   root.style.setProperty(
     "--primary",
@@ -39,9 +42,9 @@ primaryPicker.addEventListener("input", () => {
   primaryValue.innerText =
   primaryPicker.value;
 
-});
+  });
 
-secondaryPicker.addEventListener("input", () => {
+  secondaryPicker.addEventListener("input", () => {
 
   root.style.setProperty(
     "--secondary",
@@ -51,11 +54,11 @@ secondaryPicker.addEventListener("input", () => {
   secondaryValue.innerText =
   secondaryPicker.value;
 
-});
+  });
 
-/* ================= RADIUS ================= */
+  /* ================= RADIUS ================= */
 
-radiusRange.addEventListener("input", () => {
+  radiusRange.addEventListener("input", () => {
 
   const value =
   radiusRange.value + "px";
@@ -68,11 +71,11 @@ radiusRange.addEventListener("input", () => {
   radiusValue.innerText =
   value;
 
-});
+  });
 
-/* ================= BLUR ================= */
+  /* ================= BLUR ================= */
 
-blurRange.addEventListener("input", () => {
+  blurRange.addEventListener("input", () => {
 
   const value =
   blurRange.value + "px";
@@ -85,24 +88,24 @@ blurRange.addEventListener("input", () => {
   blurValue.innerText =
   value;
 
-});
+  });
 
-/* ================= DARK MODE ================= */
+  /* ================= DARK MODE ================= */
 
-themeToggle.addEventListener("change", () => {
+  themeToggle.addEventListener("change", () => {
 
   document.body.classList.toggle(
     "light-mode"
   );
 
-});
+  });
 
-/* ================= MENU ACTIVE ================= */
+  /* ================= MENU ACTIVE ================= */
 
-const links =
-document.querySelectorAll(".studio-link");
+  const links =
+  document.querySelectorAll(".studio-link");
 
-links.forEach(link => {
+  links.forEach(link => {
 
   link.addEventListener("click", () => {
 
@@ -114,4 +117,5 @@ links.forEach(link => {
 
   });
 
-});
+  });
+}

--- a/virtualclass/vc.js
+++ b/virtualclass/vc.js
@@ -7,7 +7,10 @@ const chatInput =
 const messages =
   document.getElementById("messages");
 
-sendBtn.addEventListener("click", () => {
+if (!sendBtn || !chatInput || !messages) {
+  // Page does not include the virtual class chat widget.
+} else {
+  sendBtn.addEventListener("click", () => {
 
   const text = chatInput.value.trim();
 
@@ -28,7 +31,8 @@ sendBtn.addEventListener("click", () => {
 
   chatInput.value = "";
 
-  messages.scrollTop =
-    messages.scrollHeight;
+    messages.scrollTop =
+      messages.scrollHeight;
 
-});
+  });
+}

--- a/voicecmmand/vc.js
+++ b/voicecmmand/vc.js
@@ -3,14 +3,18 @@ const statusText = document.getElementById("status");
 
 let listening = false;
 
-micBtn.addEventListener("click", () => {
-  listening = !listening;
+if (!micBtn || !statusText) {
+  // Page does not include the voice command UI.
+} else {
+  micBtn.addEventListener("click", () => {
+    listening = !listening;
 
-  micBtn.classList.toggle("active");
+    micBtn.classList.toggle("active");
 
-  if(listening){
-    statusText.textContent = "Listening...";
-  } else {
-    statusText.textContent = "Waiting for command...";
-  }
-});
+    if(listening){
+      statusText.textContent = "Listening...";
+    } else {
+      statusText.textContent = "Waiting for command...";
+    }
+  });
+}


### PR DESCRIPTION
The duplicate-registration bug I could verify is in compare.js: each frame load was nesting another load handler, which then stacked more scroll listeners on subsequent loads. I fixed that path and also made sandbox.js and url-state-integration.js idempotent so repeated init calls do not attach duplicate observers.

Validation is clean on all three files. If you want, I can do a broader pass over the remaining standalone demo carousels and widget scripts next.

closes #1232