### PR TITLE
add animated progress bar component issue 1043

### DIFF
--- a/progresBar/progress.css
+++ b/progresBar/progress.css
@@ -1,0 +1,388 @@
+/* UI-Verse Progress Indicators (Linear + Circular + Wizard/Stepper)
+   - CSS-first animations
+   - Designed to match existing "glass/neumorphism" look used across UI-Verse components
+*/
+
+:root{
+  --pv-bg: rgba(148,163,184,.25);
+  --pv-track: rgba(255,255,255,.08);
+  --pv-text: rgba(255,255,255,.92);
+  --pv-muted: rgba(255,255,255,.68);
+  --pv-glow: rgba(59,130,246,.35);
+  --pv-radius: 999px;
+  --pv-shadow1: rgba(0,0,0,.35);
+  --pv-shadow2: rgba(255,255,255,.08);
+}
+
+*{ box-sizing: border-box; }
+
+.pv-page{
+  min-height: 100vh;
+  padding: 28px 16px;
+  background:
+    radial-gradient(1000px 500px at 10% 0%, rgba(99,102,241,.22), transparent 60%),
+    radial-gradient(900px 450px at 90% 10%, rgba(56,189,248,.18), transparent 60%),
+    radial-gradient(1000px 700px at 50% 110%, rgba(34,197,94,.10), transparent 60%),
+    linear-gradient(180deg, #0b1220, #050914);
+}
+
+.pv-shell{
+  max-width: 980px;
+  margin: 0 auto;
+  display: grid;
+  gap: 18px;
+}
+
+.pv-title{
+  color: var(--pv-text);
+  font-size: 1.1rem;
+  letter-spacing: .2px;
+}
+
+.pv-card{
+  background: rgba(255,255,255,.06);
+  border: 1px solid rgba(255,255,255,.10);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 20px 60px var(--pv-shadow1), inset 0 1px 0 var(--pv-shadow2);
+}
+
+.pv-card h2{
+  margin: 0 0 10px;
+  color: var(--pv-text);
+  font-size: 1rem;
+}
+
+.pv-sub{
+  margin: 0 0 14px;
+  color: var(--pv-muted);
+  font-size: .92rem;
+  line-height: 1.3;
+}
+
+/* ---------- Linear Progress ---------- */
+
+.pv-linear{
+  --pv-percent: 0;
+  --pv-color: #3b82f6;
+  --pv-height: 16px;
+  --pv-thickness: 10px;
+
+  width: 100%;
+}
+
+.pv-linear .pv-row{
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.pv-linear .pv-label{
+  color: var(--pv-text);
+  font-weight: 600;
+  font-size: .95rem;
+}
+
+.pv-linear .pv-helper{
+  color: var(--pv-muted);
+  font-size: .9rem;
+  text-align: right;
+}
+
+.pv-linear .pv-track{
+  position: relative;
+  height: var(--pv-height);
+  border-radius: var(--pv-radius);
+  background: linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.03));
+  border: 1px solid rgba(255,255,255,.10);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,.15);
+}
+
+.pv-linear .pv-fill{
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: calc(var(--pv-percent) * 1%);
+  background:
+    linear-gradient(90deg,
+      color-mix(in srgb, var(--pv-color) 92%, white 8%),
+      color-mix(in srgb, var(--pv-color) 70%, #22c55e 30%));
+  border-radius: var(--pv-radius);
+  box-shadow: 0 0 0 1px rgba(255,255,255,.12), 0 0 24px var(--pv-glow);
+  transform: translateZ(0);
+  transition: width 700ms cubic-bezier(.2,.85,.2,1);
+}
+
+@supports not (color-mix(in srgb, red 50%, blue 50%)){
+  .pv-linear .pv-fill{
+    background: linear-gradient(90deg, var(--pv-color), #22c55e);
+  }
+}
+
+.pv-linear .pv-shine{
+  position: absolute;
+  inset: -50% -30% -50% -30%;
+  background: radial-gradient(circle at 20% 20%, rgba(255,255,255,.22), transparent 55%);
+  opacity: .35;
+  pointer-events: none;
+  animation: pv-shimmer 1.6s ease-in-out infinite;
+}
+
+@keyframes pv-shimmer{
+  0%, 100%{ transform: translateX(-8%); opacity: .22; }
+  50%{ transform: translateX(8%); opacity: .42; }
+}
+
+.pv-linear .pv-value{
+  margin-top: 10px;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--pv-muted);
+  font-size: .88rem;
+}
+
+.pv-linear .pv-value strong{
+  color: var(--pv-text);
+}
+
+.pv-linear[data-animated="true"] .pv-fill{
+  will-change: width;
+}
+
+/* ---------- Circular Progress ---------- */
+
+.pv-circular{
+  --pv-percent: 0;
+  --pv-color: #8b5cf6;
+  --pv-size: 120px;
+  --pv-stroke: 10;
+  --pv-bg-stroke: rgba(255,255,255,.10);
+
+  display: grid;
+  grid-auto-flow: row;
+  gap: 10px;
+  justify-items: center;
+}
+
+.pv-circular .pv-circle-wrap{
+  width: var(--pv-size);
+  height: var(--pv-size);
+  position: relative;
+}
+
+.pv-circular svg{
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.pv-circular .pv-track-circle{
+  fill: none;
+  stroke: var(--pv-bg-stroke);
+  stroke-width: var(--pv-stroke);
+}
+
+.pv-circular .pv-progress-circle{
+  fill: none;
+  stroke: var(--pv-color);
+  stroke-width: var(--pv-stroke);
+  stroke-linecap: round;
+  stroke-dasharray: var(--pv-circ);
+  stroke-dashoffset: calc(var(--pv-circ) * (1 - var(--pv-percent) / 100));
+  transition: stroke-dashoffset 700ms cubic-bezier(.2,.85,.2,1);
+  filter: drop-shadow(0 0 10px color-mix(in srgb, var(--pv-color) 55%, rgba(255,255,255,.2) 45%));
+}
+
+@supports not (color-mix(in srgb, red 50%, blue 50%)){
+  .pv-circular .pv-progress-circle{ filter: drop-shadow(0 0 10px rgba(139,92,246,.35)); }
+}
+
+.pv-circular .pv-center{
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 10px;
+}
+
+.pv-circular .pv-center .pv-center-text{
+  color: var(--pv-text);
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: .2px;
+}
+
+.pv-circular .pv-center .pv-center-helper{
+  margin-top: 4px;
+  color: var(--pv-muted);
+  font-size: .88rem;
+}
+
+.pv-circular .pv-label{
+  color: var(--pv-text);
+  font-weight: 600;
+  font-size: .95rem;
+}
+
+/* ---------- Wizard / Stepper ---------- */
+
+.pv-wizard{
+  --pv-color: #3b82f6;
+  display: grid;
+  gap: 12px;
+}
+
+.pv-wizard .pv-w-top{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pv-wizard .pv-step-meta{
+  display: grid;
+  gap: 4px;
+}
+
+.pv-wizard .pv-step-title{
+  color: var(--pv-text);
+  font-weight: 700;
+}
+
+.pv-wizard .pv-step-helper{
+  color: var(--pv-muted);
+  font-size: .9rem;
+}
+
+.pv-wizard .pv-step-pill{
+  color: var(--pv-text);
+  background: rgba(255,255,255,.07);
+  border: 1px solid rgba(255,255,255,.12);
+  padding: 8px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+}
+
+.pv-wizard .pv-stepper{
+  display: grid;
+  grid-template-columns: repeat(var(--pv-steps), 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.pv-wizard .pv-step-node{
+  position: relative;
+  text-align: center;
+}
+
+.pv-wizard .pv-step-node .pv-dot{
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  margin: 0 auto;
+  background: rgba(255,255,255,.07);
+  border: 1px solid rgba(255,255,255,.14);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+  transition: transform 300ms ease, background 300ms ease, border-color 300ms ease;
+}
+
+.pv-wizard .pv-step-node .pv-dot[data-state="done"],
+.pv-wizard .pv-step-node .pv-dot[data-state="active"]{
+  background: color-mix(in srgb, var(--pv-color) 55%, rgba(255,255,255,.10) 45%);
+  border-color: color-mix(in srgb, var(--pv-color) 65%, rgba(255,255,255,.25) 35%);
+  box-shadow: 0 0 20px rgba(59,130,246,.22), inset 0 1px 0 rgba(255,255,255,.08);
+}
+
+.pv-wizard .pv-step-node .pv-dot[data-state="active"]{
+  transform: scale(1.06);
+}
+
+@supports not (color-mix(in srgb, red 50%, blue 50%)){
+  .pv-wizard .pv-step-node .pv-dot[data-state="done"],
+  .pv-wizard .pv-step-node .pv-dot[data-state="active"]{
+    background: rgba(59,130,246,.35);
+    border-color: rgba(59,130,246,.55);
+  }
+}
+
+.pv-wizard .pv-step-node .pv-step-label{
+  margin-top: 8px;
+  color: var(--pv-muted);
+  font-size: .85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pv-wizard .pv-step-node[data-state="done"] .pv-step-label,
+.pv-wizard .pv-step-node[data-state="active"] .pv-step-label{
+  color: var(--pv-text);
+  font-weight: 700;
+}
+
+.pv-wizard .pv-step-bar{
+  height: 12px;
+  border-radius: var(--pv-radius);
+  background: rgba(255,255,255,.06);
+  border: 1px solid rgba(255,255,255,.10);
+  overflow: hidden;
+  position: relative;
+}
+
+.pv-wizard .pv-step-bar .pv-step-fill{
+  height: 100%;
+  width: calc(var(--pv-percent) * 1%);
+  background: linear-gradient(90deg, var(--pv-color), rgba(34,197,94,.85));
+  border-radius: var(--pv-radius);
+  transition: width 700ms cubic-bezier(.2,.85,.2,1);
+  box-shadow: 0 0 24px rgba(59,130,246,.25);
+}
+
+.pv-inline{
+  display: grid;
+  grid-template-columns: 1.1fr .9fr;
+  gap: 16px;
+  align-items: start;
+}
+
+@media (max-width: 860px){
+  .pv-inline{ grid-template-columns: 1fr; }
+}
+
+/* Small demo layout */
+.pv-grid-2{
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 860px){
+  .pv-grid-2{ grid-template-columns: 1fr; }
+}
+
+.pv-actions{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.pv-btn{
+  appearance: none;
+  border: 1px solid rgba(255,255,255,.14);
+  background: rgba(255,255,255,.06);
+  color: var(--pv-text);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.pv-btn:active{ transform: translateY(1px); }
+

--- a/progresBar/progress.html
+++ b/progresBar/progress.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>UI-Verse Progress Indicators (Linear + Circular + Wizard)</title>
+
+  <link rel="stylesheet" href="progress.css">
+</head>
+<body>
+
+  <main class="pv-page">
+    <div class="pv-shell">
+      <div>
+        <div class="pv-title">Progress Indicators</div>
+        <p class="pv-sub">
+          Linear and circular animated progress bars + a wizard/stepper mode example. Labels and helper text are optional and accessible.
+        </p>
+      </div>
+
+      <!-- Linear demo -->
+      <section class="pv-card">
+        <h2>Linear Progress (0% → 100%)</h2>
+        <div class="pv-linear" id="demo-linear" data-animated="true" style="--pv-color:#3b82f6; --pv-height:16px; --pv-percent:0;">
+          <div class="pv-row">
+            <div class="pv-label" data-pv-role="label" data-pv-template="Uploading… {percent}%">Uploading… 0%</div>
+            <div class="pv-helper" data-pv-role="helper" data-pv-template="Step 1 of 4 • {percent}%">Step 1 of 4 • 0%</div>
+          </div>
+          <div class="pv-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Linear progress">
+            <div class="pv-fill" aria-hidden="true"></div>
+            <div class="pv-shine" aria-hidden="true"></div>
+          </div>
+          <div class="pv-value">
+            <span>Progress</span>
+            <strong data-pv-role="value">0%</strong>
+          </div>
+        </div>
+      </section>
+
+      <!-- Circular demo + Dynamic demo -->
+      <section class="pv-card">
+        <h2>Circular Progress (25% → 100%) + Dynamic update</h2>
+        <div class="pv-grid-2">
+          <div>
+            <div class="pv-circular" id="demo-circular" style="--pv-color:#8b5cf6; --pv-size:128px; --pv-stroke:10; --pv-percent:25;">
+              <div class="pv-label" data-pv-role="label" data-pv-template="Loading… {percent}%">Loading… 25%</div>
+              <div class="pv-circle-wrap">
+                <svg viewBox="0 0 120 120" aria-hidden="true" focusable="false">
+                  <circle class="pv-track-circle" cx="60" cy="60" r="46"></circle>
+                  <circle class="pv-progress-circle" cx="60" cy="60" r="46" data-pv-role="progress"></circle>
+                </svg>
+                <div class="pv-center">
+                  <div>
+                    <div class="pv-center-text" data-pv-role="value">25%</div>
+                    <div class="pv-center-helper" data-pv-role="helper" data-pv-template="Ready at {percent}%">Ready at 25%</div>
+                  </div>
+                </div>
+              </div>
+              <div style="width:100%; text-align:center; color: rgba(255,255,255,.68); font-size:.88rem;">
+                <span role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="25" aria-label="Circular progress"></span>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <div class="pv-inline">
+              <div>
+                <div class="pv-linear" id="demo-dynamic-linear" data-animated="true" style="--pv-color:#22c55e; --pv-height:14px; --pv-percent:10;">
+                  <div class="pv-row">
+                    <div class="pv-label" data-pv-role="label" data-pv-template="Syncing… {percent}%">Syncing… 10%</div>
+                    <div class="pv-helper" data-pv-role="helper" data-pv-template="This updates continuously • {percent}%">This updates continuously • 10%</div>
+                  </div>
+                  <div class="pv-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="10" aria-label="Dynamic linear progress">
+                    <div class="pv-fill" aria-hidden="true"></div>
+                    <div class="pv-shine" aria-hidden="true"></div>
+                  </div>
+                  <div class="pv-value">
+                    <span>Status</span>
+                    <strong data-pv-role="value">10%</strong>
+                  </div>
+                </div>
+
+                <div class="pv-actions">
+                  <button class="pv-btn" id="pv-toggle-dynamic" type="button">Pause dynamic update</button>
+                </div>
+              </div>
+
+              <div>
+                <div class="pv-circular" id="demo-dynamic-circular" style="--pv-color:#3b82f6; --pv-size:118px; --pv-stroke:9; --pv-percent:10;">
+                  <div class="pv-label" data-pv-role="label" data-pv-template="Upload… {percent}%">Upload… 10%</div>
+                  <div class="pv-circle-wrap">
+                    <svg viewBox="0 0 120 120" aria-hidden="true" focusable="false">
+                      <circle class="pv-track-circle" cx="60" cy="60" r="44"></circle>
+                      <circle class="pv-progress-circle" cx="60" cy="60" r="44" data-pv-role="progress"></circle>
+                    </svg>
+                    <div class="pv-center">
+                      <div>
+                        <div class="pv-center-text" data-pv-role="value">10%</div>
+                        <div class="pv-center-helper" data-pv-role="helper" data-pv-template="Complete at {percent}%">Complete at 10%</div>
+                      </div>
+                    </div>
+                  </div>
+                  <div style="width:100%; text-align:center; color: rgba(255,255,255,.68); font-size:.88rem;">
+                    <span role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="10" aria-label="Dynamic circular progress"></span>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Wizard demo -->
+      <section class="pv-card">
+        <h2>Wizard/Stepper Mode</h2>
+        <div class="pv-wizard" id="demo-wizard" data-pv-total-steps="4" data-pv-current-step="2" style="--pv-color:#3b82f6;">
+
+          <div class="pv-w-top">
+            <div class="pv-step-meta">
+              <div class="pv-step-title">Onboarding Wizard</div>
+              <div class="pv-step-helper" data-pv-role="helper" data-pv-template="Step {current} of {total} • Keep going…">Step 2 of 4 • Keep going…</div>
+            </div>
+            <div class="pv-step-pill" data-pv-role="pill">2 / 4</div>
+          </div>
+
+          <div class="pv-stepper" style="--pv-steps:4;">
+            <div class="pv-step-node" data-pv-role="node" data-state="done">
+              <div class="pv-dot" data-state="done"></div>
+              <div class="pv-step-label">Account</div>
+            </div>
+            <div class="pv-step-node" data-pv-role="node" data-state="active">
+              <div class="pv-dot" data-state="active"></div>
+              <div class="pv-step-label">Profile</div>
+            </div>
+            <div class="pv-step-node" data-pv-role="node" data-state="todo">
+              <div class="pv-dot" data-state="todo"></div>
+              <div class="pv-step-label">Preferences</div>
+            </div>
+            <div class="pv-step-node" data-pv-role="node" data-state="todo">
+              <div class="pv-dot" data-state="todo"></div>
+              <div class="pv-step-label">Confirm</div>
+            </div>
+          </div>
+
+          <div class="pv-step-bar" aria-hidden="true">
+            <div class="pv-step-fill"></div>
+          </div>
+
+          <div class="pv-actions">
+            <button class="pv-btn" id="pv-wiz-prev" type="button">Previous step</button>
+            <button class="pv-btn" id="pv-wiz-next" type="button">Next step</button>
+          </div>
+
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+  <script src="progress.js"></script>
+</body>
+</html>
+

--- a/progresBar/progress.js
+++ b/progresBar/progress.js
@@ -1,0 +1,228 @@
+/* Minimal JS for UI-Verse Progress Indicators
+   - Updates linear + circular percent/value
+   - Updates wizard stepper state and label
+*/
+
+(function(){
+  function clamp(n, min, max){
+    n = Number(n);
+    if (Number.isNaN(n)) return min;
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function setLinear(el, percent){
+    percent = clamp(percent, 0, 100);
+    el.style.setProperty('--pv-percent', percent);
+
+    const valueEl = el.querySelector('[data-pv-role="value"]');
+    if(valueEl) valueEl.textContent = `${Math.round(percent)}%`;
+
+    const labelEl = el.querySelector('[data-pv-role="label"]');
+    const helperEl = el.querySelector('[data-pv-role="helper"]');
+    if(labelEl && labelEl.dataset.pvTemplate){
+      labelEl.textContent = labelEl.dataset.pvTemplate.replace('{percent}', Math.round(percent));
+    }
+    if(helperEl && helperEl.dataset.pvTemplate){
+      helperEl.textContent = helperEl.dataset.pvTemplate.replace('{percent}', Math.round(percent));
+    }
+  }
+
+  function initCircularMetrics(el){
+    // read circle radius
+    const circle = el.querySelector('circle[data-pv-role="progress"]');
+    if(!circle) return;
+    const r = Number(circle.getAttribute('r'));
+    const circ = 2 * Math.PI * r;
+    el.style.setProperty('--pv-circ', circ);
+  }
+
+  function setCircular(el, percent){
+    percent = clamp(percent, 0, 100);
+    el.style.setProperty('--pv-percent', percent);
+
+    const valueEl = el.querySelector('[data-pv-role="value"]');
+    if(valueEl) valueEl.textContent = `${Math.round(percent)}%`;
+
+    const helperEl = el.querySelector('[data-pv-role="helper"]');
+    if(helperEl && helperEl.dataset.pvTemplate){
+      helperEl.textContent = helperEl.dataset.pvTemplate.replace('{percent}', Math.round(percent));
+    }
+    const labelEl = el.querySelector('[data-pv-role="label"]');
+    if(labelEl && labelEl.dataset.pvTemplate){
+      labelEl.textContent = labelEl.dataset.pvTemplate.replace('{percent}', Math.round(percent));
+    }
+  }
+
+  function setWizard(wizEl, step, totalSteps){
+    step = clamp(step, 1, totalSteps);
+
+    const percent = totalSteps <= 1 ? 100 : ((step - 1) / (totalSteps - 1)) * 100;
+    wizEl.style.setProperty('--pv-percent', percent);
+
+    const stepPill = wizEl.querySelector('[data-pv-role="pill"]');
+    if(stepPill){
+      stepPill.textContent = `${step} / ${totalSteps}`;
+    }
+
+    wizEl.querySelectorAll('[data-pv-role="node"]').forEach((node, idx) => {
+      const nodeStep = idx + 1;
+      const state = nodeStep < step ? 'done' : (nodeStep === step ? 'active' : 'todo');
+      node.dataset.state = state;
+    });
+
+    // helper label template: "Step {current} of {total}" or similar
+    const helperEl = wizEl.querySelector('[data-pv-role="helper"]');
+    if(helperEl && helperEl.dataset.pvTemplate){
+      helperEl.textContent = helperEl.dataset.pvTemplate
+        .replace('{current}', step)
+        .replace('{total}', totalSteps);
+    }
+  }
+
+  function startDemoLinear({selector, from, to, durationMs, stepMs, color}){
+    const el = document.querySelector(selector);
+    if(!el) return;
+    if(color) el.style.setProperty('--pv-color', color);
+
+    const start = performance.now();
+    const tick = () => {
+      const now = performance.now();
+      const t = clamp((now - start) / durationMs, 0, 1);
+      const p = from + (to - from) * t;
+      setLinear(el, p);
+      if(t < 1) requestAnimationFrame(tick);
+    };
+    setLinear(el, from);
+    requestAnimationFrame(tick);
+  }
+
+  function startDemoCircular({selector, from, to, durationMs, color}){
+    const el = document.querySelector(selector);
+    if(!el) return;
+    if(color) el.style.setProperty('--pv-color', color);
+
+    initCircularMetrics(el);
+
+    const start = performance.now();
+    const tick = () => {
+      const now = performance.now();
+      const t = clamp((now - start) / durationMs, 0, 1);
+      const p = from + (to - from) * t;
+      setCircular(el, p);
+      if(t < 1) requestAnimationFrame(tick);
+    };
+    setCircular(el, from);
+    requestAnimationFrame(tick);
+  }
+
+  function startWizardDemo({selector, step, totalSteps}){
+    const wiz = document.querySelector(selector);
+    if(!wiz) return;
+    setWizard(wiz, step, totalSteps);
+  }
+
+  // Expose minimal API (optional)
+  window.UIVerseProgress = {
+    setLinear,
+    setCircular,
+    setWizard
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const linear0 = {
+      selector: '#demo-linear',
+      from: 0,
+      to: 100,
+      durationMs: 3800,
+      color: '#3b82f6'
+    };
+
+    const circular0 = {
+      selector: '#demo-circular',
+      from: 25,
+      to: 100,
+      durationMs: 4200,
+      color: '#8b5cf6'
+    };
+
+    const wizard0 = {
+      selector: '#demo-wizard',
+      step: 2,
+      totalSteps: Number(document.querySelector('#demo-wizard')?.dataset.pvTotalSteps || 4)
+    };
+
+    startDemoLinear(linear0);
+    startDemoCircular(circular0);
+    startWizardDemo(wizard0);
+
+    // Dynamic update demo (progress changes over time)
+    const dynamic = {
+      linearSel: '#demo-dynamic-linear',
+      circularSel: '#demo-dynamic-circular',
+      durationMs: 5200
+    };
+
+    const dynLinear = document.querySelector(dynamic.linearSel);
+    const dynCircular = document.querySelector(dynamic.circularSel);
+    if(dynCircular) initCircularMetrics(dynCircular);
+
+    if(dynLinear && dynCircular){
+      let running = true;
+      const start = performance.now();
+      const tick = () => {
+        if(!running) return;
+        const now = performance.now();
+        const t = ((now - start) % dynamic.durationMs) / dynamic.durationMs;
+
+        // ease in/out by using smoothstep-ish transform
+        const eased = t < 0.5 ? 2*t*t : 1 - Math.pow(-2*t+2,2)/2;
+        const p = 10 + eased * 90;
+        setLinear(dynLinear, p);
+        setCircular(dynCircular, p);
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+
+      const btn = document.querySelector('#pv-toggle-dynamic');
+      if(btn){
+        btn.addEventListener('click', () => {
+          running = !running;
+          btn.textContent = running ? 'Pause dynamic update' : 'Resume dynamic update';
+          if(running){
+            // reset start time for nicer feel
+            // easiest: reload page; but keep it simple: just resume without reset.
+            requestAnimationFrame(() => {
+              const start2 = performance.now();
+              const loop = () => {
+                if(!running) return;
+                const now = performance.now();
+                const t = ((now - start2) % dynamic.durationMs) / dynamic.durationMs;
+                const eased = t < 0.5 ? 2*t*t : 1 - Math.pow(-2*t+2,2)/2;
+                const p = 10 + eased * 90;
+                setLinear(dynLinear, p);
+                setCircular(dynCircular, p);
+                requestAnimationFrame(loop);
+              };
+              requestAnimationFrame(loop);
+            });
+          }
+        });
+      }
+    }
+
+    // Small wizard interaction: step through nodes
+    const wiz = document.querySelector('#demo-wizard');
+    const nextBtn = document.querySelector('#pv-wiz-next');
+    const prevBtn = document.querySelector('#pv-wiz-prev');
+    if(wiz && nextBtn && prevBtn){
+      const total = Number(wiz.dataset.pvTotalSteps || 4);
+      let cur = Number(wiz.dataset.pvCurrentStep || 1);
+      setWizard(wiz, cur, total);
+
+      const refresh = () => setWizard(wiz, cur, total);
+      prevBtn.addEventListener('click', () => { cur = clamp(cur - 1, 1, total); refresh(); });
+      nextBtn.addEventListener('click', () => { cur = clamp(cur + 1, 1, total); refresh(); });
+    }
+  });
+})();
+


### PR DESCRIPTION
## Related Issue
Closes #1043 

# PR: Add Animated Linear + Circular Progress Indicators (Wizard/Stepper Mode)

## Summary
UIverse now includes an enhanced progress indicator component set under `progressbar/`, supporting:
- **Linear progress bars** (percentage-based)
- **Circular progress indicators** (percentage-based, SVG stroke-dash animation)
- **Wizard/stepper mode** (multi-step progress indicator)
- **Smooth CSS-first animations** with minimal JS for dynamic updates

## Files Added
- `progressbar/progress.html`
  - Demo page including:
    - Linear progress demo (**0% → 100%**)
    - Circular progress demo (**25% → 100%**)
    - Wizard/stepper indicator with **Next/Previous**
    - Dynamic update demo (linear + circular continuously updating)
- `progressbar/progress.css`
  - Styling + animations for:
    - Linear bar + optional label/helper layout
    - Circular progress (SVG)
    - Wizard/stepper visuals
- `progressbar/progress.js`
  - Minimal JS utilities to update:
    - Linear percent + labels
    - Circular percent + labels
    - Wizard step state + helper text
  - Drives the demo animations with `requestAnimationFrame`

## Implementation Notes
- **Customizable values**: components accept percentage via CSS variable `--pv-percent`.
- **Custom colors/themes**: components accept `--pv-color` CSS variable.
- **Optional labels/helper text**: implemented via `data-pv-template` with `{percent}`, `{current}`, `{total}` placeholders.
- **Accessibility**:
  - Uses `role="progressbar"` and `aria-valuemin/max/now`.
  - Center/label text remains visible and not only color-dependent.

## How to Test
1. Open in browser:
   - `progressbar/progress.html`
2. Verify:
   - Linear demo animates from 0% to 100%
   - Circular demo animates from 25% to 100%
   - Wizard indicator updates correctly using Next/Previous buttons
   - Dynamic demo continuously updates and can be paused/resumed

