### PR TITLE
Add standalone Pagination component with ellipsis + page-size selector

### DIFF
--- a/pagination/pagination.css
+++ b/pagination/pagination.css
@@ -1,0 +1,173 @@
+/* ============================================================
+   UIverse Pagination Component Styles
+   ------------------------------------------------------------
+   Usage:
+     <div class="pagination-wrapper" id="..."> ... </div>
+   ------------------------------------------------------------
+   The JS will render elements with:
+     .pagination
+     .pagination-control
+     .pagination-btn
+     .pagination-ellipsis
+     .pagination-page (data-page)
+     .pagination-page.is-active
+     .pagination-btn.is-disabled
+   ============================================================ */
+
+:root {
+  --pagination-bg: rgba(255, 255, 255, 0.08);
+  --pagination-border: rgba(255, 255, 255, 0.12);
+  --pagination-text: rgba(255, 255, 255, 0.92);
+  --pagination-muted: rgba(255, 255, 255, 0.65);
+  --pagination-active: #eb6835;
+  --pagination-accent: #6c5ce7;
+  --pagination-disabled: rgba(255, 255, 255, 0.35);
+}
+
+/* Provide sane defaults even outside the app's theme */
+body {
+  --pagination-text: rgba(10, 10, 10, 0.9);
+  --pagination-muted: rgba(10, 10, 10, 0.55);
+}
+
+.pagination-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: var(--pagination-bg);
+  border: 1px solid var(--pagination-border);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.06);
+  overflow-x: auto;
+}
+
+.pagination-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pagination-btn {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--pagination-text);
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease, border-color 0.2s ease;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.pagination-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.08);
+  border-color: rgba(235, 104, 53, 0.35);
+}
+
+.pagination-btn.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.pagination-page {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.pagination-page.is-active {
+  background: linear-gradient(45deg, #eb6835, #6c5ce7);
+  border-color: transparent;
+  box-shadow: 0 14px 32px rgba(235, 104, 53, 0.22);
+}
+
+.pagination-ellipsis {
+  padding: 0 6px;
+  color: var(--pagination-muted);
+  font-weight: 800;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.pagination-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--pagination-muted);
+  margin-right: 2px;
+  white-space: nowrap;
+}
+
+.pagination-page-size {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.pagination-select {
+  appearance: none;
+  border-radius: 12px;
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--pagination-text);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+/* Small-screen: reduce controls */
+@media (max-width: 520px) {
+  .pagination {
+    justify-content: flex-start;
+    padding: 10px 10px;
+    gap: 8px;
+  }
+
+  /* When rendering, JS will mark some pages as data-sp="hide-mobile" */
+  .pagination-btn[data-sp="hide-mobile"] {
+    display: none;
+  }
+
+  /* Keep page buttons compact */
+  .pagination-btn {
+    padding: 8px 10px;
+    border-radius: 12px;
+  }
+}
+
+/* Dark mode support if host uses .dark-mode */
+.dark-mode .pagination {
+  background: rgba(20, 20, 30, 0.62);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.42);
+}
+
+.dark-mode .pagination-btn {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.dark-mode .pagination-ellipsis {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.dark-mode .pagination-select {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+

--- a/pagination/pagination.html
+++ b/pagination/pagination.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>UIverse Pagination — Demo</title>
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Sans:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <link rel="stylesheet" href="../button.css" />
+    <link rel="stylesheet" href="pagination.css" />
+
+    <style>
+      body {
+        font-family: 'DM Sans', sans-serif;
+        margin: 0;
+        padding: 28px 16px;
+        background: linear-gradient(-45deg, #f6f7fb, #eef1f8, #f3f0ff, #fff4ed);
+        min-height: 100vh;
+      }
+      .page {
+        max-width: 980px;
+        margin: 0 auto;
+      }
+      .section {
+        background: rgba(255,255,255,0.65);
+        backdrop-filter: blur(12px);
+        border: 1px solid rgba(255,255,255,0.6);
+        border-radius: 20px;
+        padding: 18px;
+        margin-bottom: 18px;
+      }
+      .section h2 {
+        margin: 0 0 10px;
+        font-size: 18px;
+        font-weight: 800;
+        color: #111;
+      }
+      .demo-grid {
+        display: grid;
+        gap: 14px;
+        grid-template-columns: 1fr;
+      }
+      .demo-info {
+        font-weight: 800;
+        color: rgba(10,10,10,0.65);
+        font-size: 13px;
+      }
+      .list-sim {
+        margin-top: 10px;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: 12px;
+      }
+      .fake-card {
+        background: rgba(255,255,255,0.85);
+        border: 1px solid rgba(0,0,0,0.06);
+        border-radius: 16px;
+        padding: 14px;
+        box-shadow: 0 12px 35px rgba(0,0,0,0.04);
+      }
+      .fake-card strong {
+        display: block;
+        font-size: 14px;
+      }
+      .fake-card span {
+        font-size: 12px;
+        color: rgba(0,0,0,0.6);
+        font-weight: 700;
+      }
+
+      /* Demo: mobile hint */
+      .hint {
+        margin-top: 8px;
+        font-size: 12px;
+        font-weight: 700;
+        color: rgba(0,0,0,0.55);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="page">
+      <div class="section">
+        <h2>Pagination Component — Demo</h2>
+        <div class="demo-info">
+          Includes: Prev/Next, page numbers, ellipsis for large sets,
+          and optional items-per-page selector.
+        </div>
+      </div>
+
+      <!-- Basic pagination -->
+      <div class="section">
+        <h2>1) Basic pagination (fixed page count)</h2>
+        <div class="demo-grid">
+          <div id="pagination-basic"></div>
+          <div class="list-sim" id="list-basic"></div>
+          <div class="hint">Try clicking Next/Prev and page numbers.</div>
+        </div>
+      </div>
+
+      <!-- Ellipsis pagination -->
+      <div class="section">
+        <h2>2) Ellipsis for large page sets</h2>
+        <div class="demo-grid">
+          <div id="pagination-ellipsis"></div>
+          <div class="demo-info" id="ellipsis-meta"></div>
+          <div class="hint">On many pages, ellipsis will appear when gaps exist.</div>
+        </div>
+      </div>
+
+      <!-- Page size selector -->
+      <div class="section">
+        <h2>3) Items per page selector + update simulation</h2>
+        <div class="demo-grid">
+          <div id="pagination-size"></div>
+          <div class="list-sim" id="list-size"></div>
+          <div class="hint">Changing page size resets to page 1 and re-renders results.</div>
+        </div>
+      </div>
+
+      <div class="section">
+        <h2>Responsive behavior (mobile)</h2>
+        <div class="demo-info">
+          On small screens, some non-adjacent page buttons may hide to reduce clutter
+          while keeping boundaries, active page, and ellipsis logic correct.
+        </div>
+      </div>
+    </div>
+
+    <script src="pagination.js"></script>
+
+    <script>
+      function renderFakeList(target, items, currentPage, pageSize) {
+        target.innerHTML = '';
+        const start = (currentPage - 1) * pageSize;
+        const pageItems = items.slice(start, start + pageSize);
+        for (const item of pageItems) {
+          const card = document.createElement('div');
+          card.className = 'fake-card';
+          card.innerHTML = `
+            <strong>${item.title}</strong>
+            <span>${item.tag}</span>
+          `;
+          target.appendChild(card);
+        }
+      }
+
+      // Build a fake dataset
+      const dataset = Array.from({ length: 95 }, (_, i) => ({
+        title: `Product ${i + 1}`,
+        tag: `Row #${i + 1}`
+      }));
+
+      // 1) Basic
+      const basic = Pagination.create({
+        container: '#pagination-basic',
+        totalItems: 45,
+        pageSize: 5,
+        maxVisiblePages: 7,
+        onPageChange: ({ page, pageSize }) => {
+          renderFakeList(document.getElementById('list-basic'), dataset.slice(0, 45), page, pageSize);
+        }
+      });
+
+      // Initial render for list
+      renderFakeList(document.getElementById('list-basic'), dataset.slice(0, 45), 1, 5);
+
+      // 2) Ellipsis
+      const ellipsis = Pagination.create({
+        container: '#pagination-ellipsis',
+        totalItems: 400,
+        pageSize: 10,
+        maxVisiblePages: 7,
+        onPageChange: ({ page, totalPages }) => {
+          document.getElementById('ellipsis-meta').textContent = `Active page: ${page} / ${totalPages}`;
+        }
+      });
+      document.getElementById('ellipsis-meta').textContent = `Active page: 1 / ${Math.ceil(400 / 10)}`;
+
+      // 3) Items per page selector
+      const size = Pagination.create({
+        container: '#pagination-size',
+        totalItems: 95,
+        pageSize: 10,
+        maxVisiblePages: 7,
+        showPageSizeSelector: true,
+        pageSizeOptions: [5, 10, 20, 25],
+        onPageChange: ({ page, pageSize }) => {
+          renderFakeList(document.getElementById('list-size'), dataset, page, pageSize);
+        }
+      });
+
+      renderFakeList(document.getElementById('list-size'), dataset, 1, 10);
+    </script>
+  </body>
+</html>
+

--- a/pagination/pagination.js
+++ b/pagination/pagination.js
@@ -1,0 +1,322 @@
+/**
+ * UIverse Pagination Component (Vanilla JS)
+ *
+ * Public API:
+ *   Pagination.create({
+ *     container: HTMLElement | string (selector),
+ *     totalItems: number,
+ *     pageSize: number,
+ *     maxVisiblePages: number (controls ellipsis window size),
+ *     showPageSizeSelector: boolean,
+ *     pageSizeOptions: number[],
+ *     onPageChange: ({ page, pageSize, totalPages }) => void
+ *   })
+ */
+
+(function () {
+  function clamp(n, min, max) {
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function range(start, endInclusive) {
+    const out = [];
+    for (let i = start; i <= endInclusive; i++) out.push(i);
+    return out;
+  }
+
+  function computePageItems({ totalPages, currentPage, maxVisiblePages }) {
+    // Always show: first + last.
+    // Show an interior window around currentPage.
+    // Insert ellipsis where gaps exist.
+
+    if (totalPages <= 1) return [1];
+
+    const maxInterior = Math.max(3, maxVisiblePages - 2); // minus first+last
+    const half = Math.floor(maxInterior / 2);
+
+    let windowStart = currentPage - half;
+    let windowEnd = currentPage + (maxInterior - half - 1);
+
+    windowStart = clamp(windowStart, 2, totalPages - 1);
+    windowEnd = clamp(windowEnd, 2, totalPages - 1);
+
+    // If clamping collapsed the window (near edges), try to expand it back.
+    const windowSize = windowEnd - windowStart + 1;
+    if (windowSize < maxInterior) {
+      const missing = maxInterior - windowSize;
+      windowStart = clamp(windowStart - missing, 2, totalPages - 1);
+    }
+
+    const pages = new Set();
+    pages.add(1);
+    pages.add(totalPages);
+    for (const p of range(windowStart, windowEnd)) pages.add(p);
+
+    const sorted = Array.from(pages).sort((a, b) => a - b);
+
+    const items = [];
+    for (let i = 0; i < sorted.length; i++) {
+      const p = sorted[i];
+      items.push({ type: 'page', value: p });
+
+      const next = sorted[i + 1];
+      if (next && next - p > 1) {
+        items.push({ type: 'ellipsis' });
+      }
+    }
+    return items;
+  }
+
+  function el(tag, attrs = {}, children = []) {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (k === 'className') node.className = v;
+      else if (k === 'text') node.textContent = v;
+      else if (k.startsWith('data-')) node.setAttribute(k, v);
+      else if (k === 'html') node.innerHTML = v;
+      else node.setAttribute(k, v);
+    }
+    for (const child of children) {
+      if (child == null) continue;
+      node.appendChild(child);
+    }
+    return node;
+  }
+
+  function createPaginationDOM(state) {
+    const wrapper = state.wrapper;
+    wrapper.innerHTML = '';
+
+    const sizeRow = state.showPageSizeSelector
+      ? el('div', { className: 'pagination-page-size' }, [
+          el('span', { className: 'pagination-label', text: 'Items per page' }),
+          (() => {
+            const select = el('select', {
+              className: 'pagination-select',
+              'aria-label': 'Items per page',
+              value: String(state.pageSize)
+            });
+            for (const opt of state.pageSizeOptions) {
+              const o = document.createElement('option');
+              o.value = String(opt);
+              o.textContent = String(opt);
+              if (opt === state.pageSize) o.selected = true;
+              select.appendChild(o);
+            }
+            select.addEventListener('change', () => {
+              const nextSize = Number(select.value);
+              state.pageSize = nextSize;
+              state.currentPage = 1;
+              state.render();
+              state.onPageChange?.({
+                page: state.currentPage,
+                pageSize: state.pageSize,
+                totalPages: state.totalPages
+              });
+            });
+            return select;
+          })()
+        ])
+      : null;
+
+    if (sizeRow) wrapper.appendChild(sizeRow);
+
+    const pag = el('div', { className: 'pagination', role: 'navigation' });
+
+    // Prev
+    const prevBtn = el('button', {
+      className: 'pagination-btn',
+      type: 'button',
+      'aria-label': 'Previous page'
+    }, []);
+    prevBtn.innerHTML = '&#x2039;'; // ‹
+    if (state.currentPage <= 1) prevBtn.classList.add('is-disabled');
+    prevBtn.addEventListener('click', () => {
+      if (state.currentPage <= 1) return;
+      state.currentPage -= 1;
+      state.render();
+      state.onPageChange?.({
+        page: state.currentPage,
+        pageSize: state.pageSize,
+        totalPages: state.totalPages
+      });
+    });
+
+    // Page items (with ellipsis)
+    const pagesEl = el('div', { className: 'pagination-control' });
+
+    const items = computePageItems({
+      totalPages: state.totalPages,
+      currentPage: state.currentPage,
+      maxVisiblePages: state.maxVisiblePages
+    });
+
+    // For mobile: hide pages that are far from current and not boundaries.
+    // We'll mark pages with a heuristic so CSS can hide them.
+    const mobileHideDistance = 2;
+
+    for (const item of items) {
+      if (item.type === 'ellipsis') {
+        pagesEl.appendChild(el('span', { className: 'pagination-ellipsis', text: '…' }));
+        continue;
+      }
+
+      const p = item.value;
+      const isActive = p === state.currentPage;
+
+      const btn = el('button', {
+        className: 'pagination-btn pagination-page' + (isActive ? ' is-active' : ''),
+        type: 'button',
+        'aria-current': isActive ? 'page' : 'false',
+        'data-page': String(p),
+        'aria-label': 'Page ' + String(p)
+      });
+      btn.textContent = String(p);
+
+      // Mark some pages to hide on mobile.
+      // Keep boundaries always visible.
+      const isBoundary = p === 1 || p === state.totalPages;
+      const isNear = Math.abs(p - state.currentPage) <= mobileHideDistance;
+      if (!isBoundary && !isNear) btn.setAttribute('data-sp', 'hide-mobile');
+
+      btn.disabled = isActive;
+      if (isActive) btn.classList.add('is-disabled');
+
+      btn.addEventListener('click', () => {
+        if (p === state.currentPage) return;
+        state.currentPage = p;
+        state.render();
+        state.onPageChange?.({
+          page: state.currentPage,
+          pageSize: state.pageSize,
+          totalPages: state.totalPages
+        });
+      });
+
+      pagesEl.appendChild(btn);
+    }
+
+    // Next
+    const nextBtn = el('button', {
+      className: 'pagination-btn',
+      type: 'button',
+      'aria-label': 'Next page'
+    });
+    nextBtn.innerHTML = '&#x203A;'; // ›
+    if (state.currentPage >= state.totalPages) nextBtn.classList.add('is-disabled');
+    nextBtn.addEventListener('click', () => {
+      if (state.currentPage >= state.totalPages) return;
+      state.currentPage += 1;
+      state.render();
+      state.onPageChange?.({
+        page: state.currentPage,
+        pageSize: state.pageSize,
+        totalPages: state.totalPages
+      });
+    });
+
+    pag.appendChild(prevBtn);
+    pag.appendChild(pagesEl);
+    pag.appendChild(nextBtn);
+
+    wrapper.appendChild(pag);
+
+    // Small helper text: current range
+    const totalPages = state.totalPages;
+    const from = totalPages === 0 ? 0 : (state.currentPage - 1) * state.pageSize + 1;
+    const to = Math.min(state.totalItems, state.currentPage * state.pageSize);
+
+    wrapper.appendChild(
+      el('div', {
+        style: 'font-size:12px;color:rgba(255,255,255,0.65);font-weight:700;text-align:center;',
+        className: 'pagination-meta',
+        text: state.totalItems === 0 ? '0 results' : `Showing ${from}–${to} of ${state.totalItems}`
+      })
+    );
+
+    // Adjust helper for light mode (best-effort)
+    const meta = wrapper.querySelector('.pagination-meta');
+    if (meta) {
+      meta.style.color = 'var(--pagination-muted)';
+    }
+  }
+
+  const Pagination = {
+    create(options) {
+      const container = typeof options.container === 'string'
+        ? document.querySelector(options.container)
+        : options.container;
+
+      if (!container) {
+        throw new Error('Pagination.create: container not found');
+      }
+
+      const state = {
+        wrapper: container,
+        totalItems: Number(options.totalItems ?? 0),
+        pageSize: Number(options.pageSize ?? 10),
+        currentPage: Number(options.currentPage ?? 1),
+        maxVisiblePages: Number(options.maxVisiblePages ?? 7),
+        showPageSizeSelector: Boolean(options.showPageSizeSelector ?? false),
+        pageSizeOptions: (options.pageSizeOptions && options.pageSizeOptions.length)
+          ? options.pageSizeOptions.map((n) => Number(n)).filter((n) => n > 0)
+          : [5, 10, 20, 50],
+        onPageChange: typeof options.onPageChange === 'function' ? options.onPageChange : null,
+        render: null,
+        totalPages: 0
+      };
+
+      state.render = () => {
+        state.totalPages = Math.max(1, Math.ceil(state.totalItems / state.pageSize));
+        state.currentPage = clamp(state.currentPage, 1, state.totalPages);
+        createPaginationDOM(state);
+      };
+
+      state.render();
+
+      return {
+        get state() {
+          return {
+            currentPage: state.currentPage,
+            pageSize: state.pageSize,
+            totalPages: state.totalPages,
+            totalItems: state.totalItems
+          };
+        },
+        setTotalItems(n) {
+          state.totalItems = Number(n);
+          state.currentPage = 1;
+          state.render();
+          state.onPageChange?.({
+            page: state.currentPage,
+            pageSize: state.pageSize,
+            totalPages: state.totalPages
+          });
+        },
+        setPageSize(n) {
+          state.pageSize = Number(n);
+          state.currentPage = 1;
+          state.render();
+          state.onPageChange?.({
+            page: state.currentPage,
+            pageSize: state.pageSize,
+            totalPages: state.totalPages
+          });
+        },
+        goToPage(p) {
+          state.currentPage = clamp(Number(p), 1, state.totalPages);
+          state.render();
+          state.onPageChange?.({
+            page: state.currentPage,
+            pageSize: state.pageSize,
+            totalPages: state.totalPages
+          });
+        }
+      };
+    }
+  };
+
+  // Expose globally
+  window.Pagination = Pagination;
+})();
+


### PR DESCRIPTION
## Related Issue
Closes #1045 

## Summary
UIverse lacked a standalone, reusable pagination component for list/table UIs. This PR adds a new pagination module that supports:
- Previous/Next navigation
- Page number buttons
- Ellipsis (…) for large page sets
- Active page styling and correct disabled states at boundaries
- Optional items-per-page selector
- Responsive/mobile-friendly layout (reduced number buttons via styling)

## Files added
- `pagination/pagination.html` (demo)
- `pagination/pagination.css` (styles + responsiveness)
- `pagination/pagination.js` (vanilla JS logic)

## How to use
```html
<link rel="stylesheet" href="pagination/pagination.css" />
<div id="my-pagination"></div>

<script src="pagination/pagination.js"></script>
<script>
  Pagination.create({
    container: '#my-pagination',
    totalItems: 95,
    pageSize: 10,
    maxVisiblePages: 7,
    showPageSizeSelector: true,
    pageSizeOptions: [5, 10, 20, 50],
    onPageChange: ({ page, pageSize, totalPages }) => {
      console.log(page, pageSize, totalPages);
      // render your list/table for the new page here
    }
  });
</script>
