### PR TITLE
perf: add per-component budgets support and generate components baseline

### DIFF
--- a/performance-budgets.json
+++ b/performance-budgets.json
@@ -1,8 +1,724 @@
 {
-  "maxTotalRequests": 59,
-  "maxTotalBytes": 24459586,
-  "maxJsBytes": 218535,
-  "maxCssBytes": 610857,
-  "maxImageBytes": 24455723,
-  "maxLoadTimeMs": 17000
+  "default": {
+    "maxTotalRequests": 59,
+    "maxTotalBytes": 24459586,
+    "maxJsBytes": 218535,
+    "maxCssBytes": 610857,
+    "maxImageBytes": 24455723,
+    "maxLoadTimeMs": 17000
+  },
+  "components": {
+    ".github/workflows/animatednavbar/animated.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2744,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1994,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 60
+    },
+    ".github/workflows/faqsection/faq.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 3200,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1727,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 18
+    },
+    "MyCollection.html": {
+      "maxTotalRequests": 12,
+      "maxTotalBytes": 96406,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 89240,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 54
+    },
+    "Public/a11y-dashboard.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 57963,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 15
+    },
+    "Welcome.html": {
+      "maxTotalRequests": 14,
+      "maxTotalBytes": 94251,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 92508,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 20
+    },
+    "about.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 724652,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 260130,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 13490
+    },
+    "alerts.html": {
+      "maxTotalRequests": 21,
+      "maxTotalBytes": 496109,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 242102,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 6165
+    },
+    "animatedherosection/hero.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 3388,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 2481,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 11
+    },
+    "animatedprofilecard/profilecard.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2609,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1772,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 11
+    },
+    "article.html": {
+      "maxTotalRequests": 34,
+      "maxTotalBytes": 754469,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 130094,
+      "maxImageBytes": 168498,
+      "maxLoadTimeMs": 3137
+    },
+    "badge.html": {
+      "maxTotalRequests": 21,
+      "maxTotalBytes": 563442,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 136995,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 6617
+    },
+    "badges.html": {
+      "maxTotalRequests": 45,
+      "maxTotalBytes": 768207,
+      "maxJsBytes": 64625,
+      "maxCssBytes": 232623,
+      "maxImageBytes": 178984,
+      "maxLoadTimeMs": 2378
+    },
+    "blog.html": {
+      "maxTotalRequests": 27,
+      "maxTotalBytes": 3454829,
+      "maxJsBytes": 43841,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 2649346,
+      "maxLoadTimeMs": 42047
+    },
+    "button.html": {
+      "maxTotalRequests": 47,
+      "maxTotalBytes": 870743,
+      "maxJsBytes": 71878,
+      "maxCssBytes": 300028,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 4139
+    },
+    "calendar.html": {
+      "maxTotalRequests": 18,
+      "maxTotalBytes": 287979,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 266744,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 452
+    },
+    "cards.html": {
+      "maxTotalRequests": 48,
+      "maxTotalBytes": 913586,
+      "maxJsBytes": 71878,
+      "maxCssBytes": 322160,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 3004
+    },
+    "carousel.html": {
+      "maxTotalRequests": 15,
+      "maxTotalBytes": 188735,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 187860,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 22
+    },
+    "charts.html": {
+      "maxTotalRequests": 17,
+      "maxTotalBytes": 227128,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 222935,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 459
+    },
+    "color.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 740334,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 261705,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 2390
+    },
+    "compare.html": {
+      "maxTotalRequests": 14,
+      "maxTotalBytes": 97091,
+      "maxJsBytes": 5387,
+      "maxCssBytes": 89240,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 54
+    },
+    "contact.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 724656,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 260130,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 8174
+    },
+    "contactform/form.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2294,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1539,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "contributorss.html": {
+      "maxTotalRequests": 59,
+      "maxTotalBytes": 1958861,
+      "maxJsBytes": 5543,
+      "maxCssBytes": 128196,
+      "maxImageBytes": 1367038,
+      "maxLoadTimeMs": 5115
+    },
+    "darkmode/mode.html": {
+      "maxTotalRequests": 4,
+      "maxTotalBytes": 24798,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 23866,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 581
+    },
+    "data/snippets/alerts/alerts.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 11100,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 26
+    },
+    "data/snippets/badges/badges.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 9984,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 26
+    },
+    "data/snippets/button/button.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 37914,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 15
+    },
+    "data/snippets/cards/cards.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 56052,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 20
+    },
+    "data/snippets/color/color.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 24122,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 15
+    },
+    "data/snippets/footer/footer.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 21038,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 12
+    },
+    "data/snippets/form/form.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 4068,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 15
+    },
+    "data/snippets/index/index.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 10848,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 8
+    },
+    "data/snippets/navbar/navbar.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 27752,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 11
+    },
+    "data/snippets/pricing/pricing.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 13200,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "data/snippets/settings/settings.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 3999,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 33
+    },
+    "data/snippets/testimonials/testimonials.html": {
+      "maxTotalRequests": 4,
+      "maxTotalBytes": 11756,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 7749,
+      "maxLoadTimeMs": 597
+    },
+    "data/snippets/toggles/toggles.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 28250,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 14
+    },
+    "div.html": {
+      "maxTotalRequests": 21,
+      "maxTotalBytes": 568080,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 141030,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 12466
+    },
+    "documentation.html": {
+      "maxTotalRequests": 23,
+      "maxTotalBytes": 681612,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 255478,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 6191
+    },
+    "drapdrop/drap.html": {
+      "maxTotalRequests": 4,
+      "maxTotalBytes": 3567,
+      "maxJsBytes": 1402,
+      "maxCssBytes": 1404,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 18
+    },
+    "ecommerce.html": {
+      "maxTotalRequests": 16,
+      "maxTotalBytes": 135285,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 127535,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 530
+    },
+    "ecommerce/ecommerce.html": {
+      "maxTotalRequests": 8,
+      "maxTotalBytes": 24459586,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 2094,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 72009
+    },
+    "faq.html": {
+      "maxTotalRequests": 15,
+      "maxTotalBytes": 108707,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 105111,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 412
+    },
+    "footer.html": {
+      "maxTotalRequests": 23,
+      "maxTotalBytes": 696285,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 252393,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 3059
+    },
+    "form.html": {
+      "maxTotalRequests": 32,
+      "maxTotalBytes": 1543678,
+      "maxJsBytes": 43841,
+      "maxCssBytes": 1468144,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 335
+    },
+    "forms.html": {
+      "maxTotalRequests": 45,
+      "maxTotalBytes": 797128,
+      "maxJsBytes": 64625,
+      "maxCssBytes": 267088,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 5909
+    },
+    "gallery.html": {
+      "maxTotalRequests": 28,
+      "maxTotalBytes": 2300882,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 127328,
+      "maxImageBytes": 2081345,
+      "maxLoadTimeMs": 22424
+    },
+    "guidelines.html": {
+      "maxTotalRequests": 15,
+      "maxTotalBytes": 116709,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 109882,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 630
+    },
+    "howtocontribute.html": {
+      "maxTotalRequests": 21,
+      "maxTotalBytes": 555486,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 129234,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 2417
+    },
+    "image-carousel.html": {
+      "maxTotalRequests": 20,
+      "maxTotalBytes": 468995,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 229566,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 4896
+    },
+    "imagecarousel/image.html": {
+      "maxTotalRequests": 4,
+      "maxTotalBytes": 3624,
+      "maxJsBytes": 1193,
+      "maxCssBytes": 1527,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 26
+    },
+    "imagegrid/grid.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 1916,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1102,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 10
+    },
+    "index.html": {
+      "maxTotalRequests": 41,
+      "maxTotalBytes": 663297,
+      "maxJsBytes": 64625,
+      "maxCssBytes": 157016,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 2596
+    },
+    "inputs.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 745324,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 255770,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 7514
+    },
+    "license.html": {
+      "maxTotalRequests": 23,
+      "maxTotalBytes": 680194,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 254356,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 2061
+    },
+    "loaders.html": {
+      "maxTotalRequests": 23,
+      "maxTotalBytes": 687107,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 257303,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 8462
+    },
+    "loadinganimation/loading.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2168,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1548,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "logincard/login.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 3347,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 2312,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 10
+    },
+    "map.html": {
+      "maxTotalRequests": 47,
+      "maxTotalBytes": 1522869,
+      "maxJsBytes": 220904,
+      "maxCssBytes": 599222,
+      "maxImageBytes": 698970,
+      "maxLoadTimeMs": 2309
+    },
+    "menu.html": {
+      "maxTotalRequests": 16,
+      "maxTotalBytes": 230379,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 224102,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 22
+    },
+    "musicplayer/player.html": {
+      "maxTotalRequests": 4,
+      "maxTotalBytes": 2768,
+      "maxJsBytes": 338,
+      "maxCssBytes": 1534,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 10
+    },
+    "navbar.html": {
+      "maxTotalRequests": 45,
+      "maxTotalBytes": 819023,
+      "maxJsBytes": 64625,
+      "maxCssBytes": 270270,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 2685
+    },
+    "navigation/ui.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2009,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1090,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "neonbutton/button.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2297,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1734,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "offline.html": {
+      "maxTotalRequests": 2,
+      "maxTotalBytes": 1001,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 610857,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "otpinput/otp.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2487,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1629,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 11
+    },
+    "portfolio/port.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 5422,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 2751,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "pricing.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 739024,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 272038,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 2884
+    },
+    "pricingpage.html": {
+      "maxTotalRequests": 14,
+      "maxTotalBytes": 93152,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 91366,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 26
+    },
+    "privacypolicy.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 729167,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 260643,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 8362
+    },
+    "product-slider.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 8854432,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 125771,
+      "maxImageBytes": 8448741,
+      "maxLoadTimeMs": 72015
+    },
+    "profilecard/card.html": {
+      "maxTotalRequests": 6,
+      "maxTotalBytes": 172846,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 24618,
+      "maxImageBytes": 6209,
+      "maxLoadTimeMs": 4428
+    },
+    "progressbar/bar.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 2200,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1244,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "radiobutton/button.html": {
+      "maxTotalRequests": 3,
+      "maxTotalBytes": 3099,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 1781,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 9
+    },
+    "searchbar/search.html": {
+      "maxTotalRequests": 4,
+      "maxTotalBytes": 24669,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 23958,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 410
+    },
+    "section.html": {
+      "maxTotalRequests": 17,
+      "maxTotalBytes": 225935,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 222371,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 498
+    },
+    "settings.html": {
+      "maxTotalRequests": 33,
+      "maxTotalBytes": 531066,
+      "maxJsBytes": 38046,
+      "maxCssBytes": 207286,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 1814
+    },
+    "source.html": {
+      "maxTotalRequests": 22,
+      "maxTotalBytes": 459808,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 239646,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 3447
+    },
+    "span.html": {
+      "maxTotalRequests": 27,
+      "maxTotalBytes": 861021,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 300490,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 10221
+    },
+    "table.html": {
+      "maxTotalRequests": 21,
+      "maxTotalBytes": 484667,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 248843,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 1906
+    },
+    "tabs.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 742775,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 261338,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 6520
+    },
+    "terms.html": {
+      "maxTotalRequests": 22,
+      "maxTotalBytes": 534795,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 252262,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 5423
+    },
+    "test-command-palette.html": {
+      "maxTotalRequests": 4,
+      "maxTotalBytes": 25659,
+      "maxJsBytes": 11930,
+      "maxCssBytes": 5984,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 62
+    },
+    "test-url-state.html": {
+      "maxTotalRequests": 5,
+      "maxTotalBytes": 30462,
+      "maxJsBytes": 14650,
+      "maxCssBytes": 3765,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 148
+    },
+    "testimonials.html": {
+      "maxTotalRequests": 33,
+      "maxTotalBytes": 258312,
+      "maxJsBytes": 38046,
+      "maxCssBytes": 204538,
+      "maxImageBytes": 7749,
+      "maxLoadTimeMs": 545
+    },
+    "timeline.html": {
+      "maxTotalRequests": 16,
+      "maxTotalBytes": 127954,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 124516,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 1220
+    },
+    "toast/noti.html": {
+      "maxTotalRequests": 5,
+      "maxTotalBytes": 213224,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 24011,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 5987
+    },
+    "toasts.html": {
+      "maxTotalRequests": 17,
+      "maxTotalBytes": 174958,
+      "maxJsBytes": 2729,
+      "maxCssBytes": 107507,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 1131
+    },
+    "toggles.html": {
+      "maxTotalRequests": 24,
+      "maxTotalBytes": 746673,
+      "maxJsBytes": 218535,
+      "maxCssBytes": 263718,
+      "maxImageBytes": 24455723,
+      "maxLoadTimeMs": 7790
+    }
+  }
 }

--- a/scripts/perf-budgets.js
+++ b/scripts/perf-budgets.js
@@ -13,10 +13,12 @@ const defaultBudgets = {
   maxLoadTimeMs: 3000
 };
 
-let budgets = defaultBudgets;
+let budgets = { default: defaultBudgets, components: {} };
 if (fs.existsSync(budgetsPath)) {
   try {
-    budgets = Object.assign({}, defaultBudgets, JSON.parse(fs.readFileSync(budgetsPath, 'utf8')));
+    const parsed = JSON.parse(fs.readFileSync(budgetsPath, 'utf8'));
+    budgets.default = Object.assign({}, defaultBudgets, parsed.default || parsed);
+    budgets.components = parsed.components || {};
   } catch (e) {
     console.error('Failed to parse performance-budgets.json, using defaults', e.message);
   }
@@ -96,6 +98,7 @@ async function main() {
 
   const generateBaseline = process.argv.includes('--generate-baseline') || process.argv.includes('-g');
   const observed = [];
+  const perPageObserved = {};
 
   const browser = await chromium.launch();
   const failures = [];
@@ -109,13 +112,17 @@ async function main() {
     try {
       const metrics = await inspectPage(browser, route);
       observed.push(metrics);
+      perPageObserved[rel] = metrics;
+
+      // determine budgets for this page: per-component override or default
+      const pageBudgets = budgets.components[rel] || budgets.default;
       const msgs = [];
-      if (metrics.totalRequests > budgets.maxTotalRequests) msgs.push(`requests ${metrics.totalRequests} > ${budgets.maxTotalRequests}`);
-      if (metrics.totalBytes > budgets.maxTotalBytes) msgs.push(`totalBytes ${(metrics.totalBytes/1024|0)}KB > ${(budgets.maxTotalBytes/1024|0)}KB`);
-      if (metrics.jsBytes > budgets.maxJsBytes) msgs.push(`js ${(metrics.jsBytes/1024|0)}KB > ${(budgets.maxJsBytes/1024|0)}KB`);
-      if (metrics.cssBytes > budgets.maxCssBytes) msgs.push(`css ${(metrics.cssBytes/1024|0)}KB > ${(budgets.maxCssBytes/1024|0)}KB`);
-      if (metrics.imageBytes > budgets.maxImageBytes) msgs.push(`images ${(metrics.imageBytes/1024|0)}KB > ${(budgets.maxImageBytes/1024|0)}KB`);
-      if (metrics.loadTime > budgets.maxLoadTimeMs) msgs.push(`loadTime ${metrics.loadTime}ms > ${budgets.maxLoadTimeMs}ms`);
+      if (metrics.totalRequests > pageBudgets.maxTotalRequests) msgs.push(`requests ${metrics.totalRequests} > ${pageBudgets.maxTotalRequests}`);
+      if (metrics.totalBytes > pageBudgets.maxTotalBytes) msgs.push(`totalBytes ${(metrics.totalBytes/1024|0)}KB > ${(pageBudgets.maxTotalBytes/1024|0)}KB`);
+      if (metrics.jsBytes > pageBudgets.maxJsBytes) msgs.push(`js ${(metrics.jsBytes/1024|0)}KB > ${(pageBudgets.maxJsBytes/1024|0)}KB`);
+      if (metrics.cssBytes > pageBudgets.maxCssBytes) msgs.push(`css ${(metrics.cssBytes/1024|0)}KB > ${(pageBudgets.maxCssBytes/1024|0)}KB`);
+      if (metrics.imageBytes > pageBudgets.maxImageBytes) msgs.push(`images ${(metrics.imageBytes/1024|0)}KB > ${(pageBudgets.maxImageBytes/1024|0)}KB`);
+      if (metrics.loadTime > pageBudgets.maxLoadTimeMs) msgs.push(`loadTime ${metrics.loadTime}ms > ${pageBudgets.maxLoadTimeMs}ms`);
 
       if (msgs.length) {
         failures.push({ page: rel, metrics, reasons: msgs });
@@ -130,6 +137,30 @@ async function main() {
   }
 
   await browser.close();
+
+  const generateComponents = process.argv.includes('--generate-components') || process.argv.includes('-C');
+  if (generateComponents) {
+    // compute per-page budgets and write them under 'components' key
+    const componentsBudgets = {};
+    for (const [rel, m] of Object.entries(perPageObserved)) {
+      componentsBudgets[rel] = {
+        maxTotalRequests: Math.ceil((m.totalRequests || 0) * 1.2) || budgets.default.maxTotalRequests,
+        maxTotalBytes: Math.ceil((m.totalBytes || 0) * 1.2) || budgets.default.maxTotalBytes,
+        maxJsBytes: Math.ceil((m.jsBytes || 0) * 1.2) || budgets.default.maxJsBytes,
+        maxCssBytes: Math.ceil((m.cssBytes || 0) * 1.2) || budgets.default.maxCssBytes,
+        maxImageBytes: Math.ceil((m.imageBytes || 0) * 1.2) || budgets.default.maxImageBytes,
+        maxLoadTimeMs: Math.ceil((m.loadTime || 0) * 1.2) || budgets.default.maxLoadTimeMs
+      };
+    }
+
+    const out = {
+      default: budgets.default,
+      components: componentsBudgets
+    };
+    fs.writeFileSync(budgetsPath, JSON.stringify(out, null, 2), 'utf8');
+    console.log('\nWrote per-component budgets to performance-budgets.json');
+    process.exit(0);
+  }
 
   if (generateBaseline) {
     // compute maxima and write to performance-budgets.json
@@ -150,9 +181,11 @@ async function main() {
       maxImageBytes: Math.ceil((max.imageBytes || 0) * 1.2) || budgets.maxImageBytes,
       maxLoadTimeMs: Math.ceil((max.loadTime || 0) * 1.2) || budgets.maxLoadTimeMs
     };
-    fs.writeFileSync(budgetsPath, JSON.stringify(newBudgets, null, 2), 'utf8');
+    // write merged default + empty components mapping
+    const out = { default: newBudgets, components: budgets.components || {} };
+    fs.writeFileSync(budgetsPath, JSON.stringify(out, null, 2), 'utf8');
     console.log('\nWrote performance-budgets.json with generated baseline:');
-    console.log(JSON.stringify(newBudgets, null, 2));
+    console.log(JSON.stringify(out, null, 2));
     process.exit(0);
   }
 


### PR DESCRIPTION
## Related Issue
Closes #1256 

## Summary
This PR adds per-component performance budgets.

## Changes Made
- Updated the performance budget script to support default and component-specific budgets.
- Generated a new `performance-budgets.json` file with per-page budget values.
- Added a flag to create per-component budgets from current site performance.

## Testing
- Ran `node -c scripts/perf-budgets.js`
- Ran `node scripts/perf-budgets.js --generate-components`
- Ran `node scripts/perf-budgets.js`

## Screenshots
Not needed for this change.

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included