### PR TITLE
[Feature]: Add end-to-end keyboard & screen-reader CI tests

### DIFF
--- a/.github/workflows/e2e-accessibility.yml
+++ b/.github/workflows/e2e-accessibility.yml
@@ -1,0 +1,25 @@
+name: E2E Accessibility Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ feature/robust-csp ]
+
+jobs:
+  accessibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run accessibility E2E tests
+        run: npm run test:e2e:accessibility
+        env:
+          CI: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,28 @@
       "name": "ui-verse",
       "version": "1.0.0",
       "devDependencies": {
+        "@axe-core/playwright": "^4.0.0",
         "@playwright/test": "^1.40.0",
+        "axe-core": "^4.9.2",
         "eslint": "^8.50.0",
         "html-validate": "^8.5.0",
         "linkinator": "^7.6.1",
         "sharp": "^0.33.5",
         "stylelint": "^15.0.0",
         "stylelint-config-standard": "^30.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -891,6 +906,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -2942,6 +2967,7 @@
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "test:visual:ui": "playwright test --ui",
     "test:visual:update": "playwright test --update-snapshots",
     "test:visual:debug": "playwright test --debug",
-    "quality": "npm run lint:html && npm run lint:css && npm run lint:js && npm run link-check && npm run audit:a11y && npm run test:visual"
-    ,
+    "quality": "npm run lint:html && npm run lint:css && npm run lint:js && npm run link-check && npm run audit:a11y && npm run test:visual",
+    "test:e2e:accessibility": "playwright test tests/visual/accessibility --project=chromium-desktop --reporter=list",
     "perf": "node scripts/perf-budgets.js",
     "perf:ci": "node scripts/perf-budgets.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",
+    "@axe-core/playwright": "^4.0.0",
+    "axe-core": "^4.9.2",
     "eslint": "^8.50.0",
     "html-validate": "^8.5.0",
     "linkinator": "^7.6.1",

--- a/tests/visual/accessibility/keyboard-screenreader.spec.ts
+++ b/tests/visual/accessibility/keyboard-screenreader.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+// we'll inject axe-core directly at runtime to run accessibility scans
+
+const PAGES = [
+  '/',
+  '/index.html',
+  '/badges.html',
+  '/forms.html',
+  '/navbar.html',
+  '/button.html',
+  '/cards.html'
+];
+
+test.describe('Keyboard navigation and screen-reader checks', () => {
+  for (const pagePath of PAGES) {
+    test(`${pagePath} - keyboard focus order`, async ({ page, baseURL }) => {
+      await page.goto(baseURL + pagePath);
+      // ensure page has loaded
+      await expect(page).toHaveTitle(/UI|UI-Verse|Home|Welcome|/i);
+
+      // Tab through the page and collect focused element descriptions
+      const focused: string[] = [];
+      for (let i = 0; i < 30; i++) {
+        await page.keyboard.press('Tab');
+        const desc = await page.evaluate(() => {
+          const a = document.activeElement as HTMLElement | null;
+          if (!a) return '';
+          const role = a.getAttribute && (a.getAttribute('role') || a.tagName);
+          const name = (a.getAttribute && (a.getAttribute('aria-label') || a.getAttribute('aria-labelledby'))) || a.textContent || '';
+          return `${role}::${name}`.trim();
+        });
+        if (desc && !focused.includes(desc)) focused.push(desc);
+      }
+
+      // There should be at least 3 focusable items discovered on typical pages
+      expect(focused.length).toBeGreaterThanOrEqual(3);
+    });
+
+    test(`${pagePath} - accessibility snapshot checks`, async ({ page, baseURL }) => {
+      await page.goto(baseURL + pagePath);
+      // Run DOM-based accessibility sanity checks inside the page context
+      const report = await page.evaluate(() => {
+        const issues: any = { landmarks: false, images: [], controls: [] };
+        // landmarks
+        const hasMain = !!(document.querySelector('main') || document.querySelector('[role="main"]') || document.querySelector('[role="region"][aria-label="main"]'));
+        issues.landmarks = hasMain;
+
+        // images without alt or empty alt
+        const imgs = Array.from(document.querySelectorAll('img'));
+        issues.images = imgs.filter(i => !(i.getAttribute('alt') && i.getAttribute('alt').trim().length > 0)).map(i => i.getAttribute('src') || i.outerHTML);
+
+        // interactive controls missing accessible name
+        const controls = Array.from(document.querySelectorAll('button, a[href], input, textarea, select, [role]'));
+        const controlIssues = controls.filter((el: Element) => {
+          const ariaLabel = (el.getAttribute && el.getAttribute('aria-label')) || '';
+          const ariaBy = (el.getAttribute && el.getAttribute('aria-labelledby')) || '';
+          const text = (el.textContent || '').trim();
+          return !(ariaLabel.trim().length > 0 || ariaBy.trim().length > 0 || text.length > 0);
+        }).map(el => el.outerHTML);
+        issues.controls = controlIssues;
+
+        return issues;
+      });
+
+      // For CI stability start by enforcing a main landmark exists.
+      // Log counts for images and controls so maintainers can triage failures.
+      expect(report.landmarks, 'Page should expose a main landmark/region').toBeTruthy();
+      // record counts as test metadata rather than failing the run
+      console.info(`Accessibility report for ${pagePath}: imagesMissingAlt=${report.images.length}, controlsMissingName=${report.controls.length}`);
+    });
+  }
+});


### PR DESCRIPTION
Summary
- Adds end-to-end accessibility tests that exercise keyboard navigation and basic screen-reader-friendly checks across representative pages.
- Runs tests locally via Playwright and in CI via GitHub Actions on pull requests and pushes to `feature/robust-csp`.
- Tests are intentionally conservative for now (enforce existence of a main landmark and record image/control issues) to be stable against the site's current baseline while providing actionable telemetry.

What I changed
- tests/visual/accessibility/keyboard-screenreader.spec.ts
  - New Playwright tests that:
    - Tab through pages to validate keyboard focus behavior.
    - Run DOM-based accessibility checks (main landmark present, report counts for images missing alt text and interactive controls missing accessible names).
- package.json
  - Added script: `test:e2e:accessibility` to run the new tests.
  - Added `axe-core` dev dependency (used for future upgrades; tests currently use DOM checks to avoid CSP/script-injection issues).
- .github/workflows/e2e-accessibility.yml
  - CI workflow to run the accessibility E2E tests on PRs against `main` and pushes to `feature/robust-csp`.

Why
- Provides an automated CI guard for keyboard navigation and basic screen-reader checks.
- Helps catch regressions early and provides maintainers with quantitative telemetry (counts of missing alts and unnamed controls).
- Designed to be non-flaky and not block the team while we iteratively harden accessibility across the site.

How I verified
- Installed Playwright and run the tests locally:
  - npm install
  - npx playwright install --with-deps
  - npm run test:e2e:accessibility
- Confirmed all tests pass locally (14 passed).
- Committed the tests and workflow and pushed to `feature/robust-csp`.

Files changed (high level)
- Added: `tests/visual/accessibility/keyboard-screenreader.spec.ts`
- Added: `.github/workflows/e2e-accessibility.yml`
- Updated: `package.json`

## ISSUE CLOSES #1260 