### PR TITLE
feat: add staggered entrance animations to card grids

### DIFF
--- a/home.css
+++ b/home.css
@@ -601,7 +601,15 @@ body.dark-mode .hero-stats {
 .feature-card.in-view {
   opacity: 1;
   transform: translateY(0);
+  transition: opacity 0.5s ease, transform 0.5s ease, box-shadow var(--transition), border-color var(--transition);
 }
+
+.feature-card:nth-child(1).in-view { transition-delay: 0.05s; }
+.feature-card:nth-child(2).in-view { transition-delay: 0.1s; }
+.feature-card:nth-child(3).in-view { transition-delay: 0.15s; }
+.feature-card:nth-child(4).in-view { transition-delay: 0.2s; }
+.feature-card:nth-child(5).in-view { transition-delay: 0.25s; }
+.feature-card:nth-child(6).in-view { transition-delay: 0.3s; }
 
 .feature-card:hover {
   transform: translateY(-6px);
@@ -702,7 +710,17 @@ body.dark-mode .feature-card:hover {
 .cat-card.in-view {
   opacity: 1;
   transform: translateY(0);
+  transition: opacity 0.5s ease, transform 0.5s ease, box-shadow var(--transition), border-color var(--transition);
 }
+
+.cat-card:nth-child(1).in-view { transition-delay: 0.05s; }
+.cat-card:nth-child(2).in-view { transition-delay: 0.1s; }
+.cat-card:nth-child(3).in-view { transition-delay: 0.15s; }
+.cat-card:nth-child(4).in-view { transition-delay: 0.2s; }
+.cat-card:nth-child(5).in-view { transition-delay: 0.25s; }
+.cat-card:nth-child(6).in-view { transition-delay: 0.3s; }
+.cat-card:nth-child(7).in-view { transition-delay: 0.35s; }
+.cat-card:nth-child(8).in-view { transition-delay: 0.4s; }
 
 .cat-card:hover {
   border-color: var(--accent);
@@ -763,7 +781,15 @@ body.dark-mode .feature-card:hover {
 .why-card.in-view {
   opacity: 1;
   transform: translateY(0);
+  transition: opacity 0.5s ease, transform 0.5s ease, box-shadow var(--transition), border-color var(--transition);
 }
+
+.why-card:nth-child(1).in-view { transition-delay: 0.05s; }
+.why-card:nth-child(2).in-view { transition-delay: 0.1s; }
+.why-card:nth-child(3).in-view { transition-delay: 0.15s; }
+.why-card:nth-child(4).in-view { transition-delay: 0.2s; }
+.why-card:nth-child(5).in-view { transition-delay: 0.25s; }
+.why-card:nth-child(6).in-view { transition-delay: 0.3s; }
 
 .why-card:hover {
   border-color: rgba(235,104,53,0.3);


### PR DESCRIPTION
Closes #1560
 
## Summary
Adds staggered transition delays to feature cards, category cards, and why cards for a polished cascading entrance animation.
## Changes Made
- Added transition-delay to .feature-card:nth-child(n).in-view (0.05s increments)
- Added transition-delay to .cat-card:nth-child(n).in-view (0.05s increments)
- Added transition-delay to .why-card:nth-child(n).in-view (0.05s increments)
- Separated transition properties for smoother animation
## Testing
- Verified staggered animation on scroll
- Confirmed no animation jank
- Tested on mobile and desktop
## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included