### PR TITLE
feat: add smooth visual feedback with transitions for form validation states

### DIFF
--- a/style.css
+++ b/style.css
@@ -2081,17 +2081,36 @@ select[readonly] {
 }
 
 /* Input with Required Attribute */
-input[required]:invalid,
-textarea[required]:invalid,
+input[required]:invalid:not(:placeholder-shown),
+textarea[required]:invalid:not(:placeholder-shown),
 select[required]:invalid {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.15);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[required]:valid:not(:placeholder-shown),
+textarea[required]:valid:not(:placeholder-shown),
+select[required]:valid {
+  border-color: #28a745;
+  box-shadow: 0 0 0 3px rgba(40, 167, 69, 0.15);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Form Validation Visual Feedback */
+.form-field {
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.form-field input:invalid:not(:placeholder-shown):not(:focus) {
   border-color: #dc3545;
 }
 
-input[required]:valid,
-textarea[required]:valid,
-select[required]:valid {
+.form-field input:valid:not(:placeholder-shown) {
   border-color: #28a745;
 }
+
 .input[type="checkbox"] {
   width: auto;
   margin-right: 8px;


### PR DESCRIPTION
## Related Issue
Closes #1602 
## Summary
Enhances form validation visual feedback with smooth transitions, placeholder-shown awareness, and subtle box-shadow glow effects.
## Changes Made
- Added `:not(:placeholder-shown)` to avoid showing errors on empty untouched fields
- Added smooth `transition` for `border-color` and `box-shadow` on validation states
- Added subtle red box-shadow glow for invalid state (`rgba(220, 53, 69, 0.15)`)
- Added subtle green box-shadow glow for valid state (`rgba(40, 167, 69, 0.15)`)
- Added `.form-field` wrapper class for better form field structure
## Testing
- Verified validation only shows after user types in field
- Confirmed smooth color transitions on valid/invalid states
- Tested with different input types (text, email, password)
- Checked that focus state overrides validation colors properly
## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
