### PR TITLE
Add missing aria-labels to interactive elements

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -49,14 +49,14 @@
   </button>
   <div class="logo">UIverse</div>
   <div class="search-bar">
-    <i class="fa-solid fa-magnifying-glass search-icon"></i>
-    <input type="text" placeholder="Search components..." />
+    <i class="fa-solid fa-magnifying-glass search-icon" aria-hidden="true"></i>
+    <input type="text" placeholder="Search components..." aria-label="Search components" />
     <kbd class="search-kbd">⌘K</kbd>
   </div>
   <div class="nav-right">
-    <button class="nav-btn outline-nav-btn"><i class="fa-solid fa-plus"></i> Add Component</button>
-    <button class="nav-btn primary-nav-btn"><i class="fa-solid fa-bookmark"></i> My Collection</button>
-    <button id="darkModeToggle" class="theme-toggle"><i class="fa-solid fa-moon"></i></button>
+    <button class="nav-btn outline-nav-btn" aria-label="Add new component"><i class="fa-solid fa-plus"></i> Add Component</button>
+    <button class="nav-btn primary-nav-btn" aria-label="View my collection"><i class="fa-solid fa-bookmark"></i> My Collection</button>
+    <button id="darkModeToggle" class="theme-toggle" aria-label="Toggle dark mode"><i class="fa-solid fa-moon" aria-hidden="true"></i></button>
   </div>
 </header>
 
@@ -107,8 +107,8 @@
         </div>
       </div>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('fc1', this)"><i class="fa-solid fa-code"></i> View Code</button>
-        <button class="action-btn copy-btn" onclick="copyCode('fc1', this)"><i class="fa-solid fa-copy"></i> Copy</button>
+        <button class="action-btn view-btn" onclick="toggleCode('fc1', this)" aria-label="View code for Login Form"><i class="fa-solid fa-code"></i> View Code</button>
+        <button class="action-btn copy-btn" onclick="copyCode('fc1', this)" aria-label="Copy code for Login Form"><i class="fa-solid fa-copy"></i> Copy</button>
       </div>
       <pre id="fc1" class="code-block"><code>&lt;div class="form-card"&gt;
   &lt;h3&gt;Welcome back&lt;/h3&gt;
@@ -271,8 +271,8 @@
 </main>
 
 <!-- Scroll to Top -->
-<button id="scrollTopBtn" onclick="scrollToTop()">
-  <i class="fa-solid fa-chevron-up"></i>
+<button id="scrollTopBtn" onclick="scrollToTop()" aria-label="Scroll to top">
+  <i class="fa-solid fa-chevron-up" aria-hidden="true"></i>
 </button>
 
 <!-- FOOTER -->


### PR DESCRIPTION
## Related Issue
Closes #1571 
## Summary
Adds aria-label attributes to interactive elements across the homepage for improved screen reader accessibility.
## Changes Made
- Added `aria-label="Search components"` to search input field
- Added `aria-label="Add new component"` to Add Component button
- Added `aria-label="View my collection"` to My Collection button
- Added `aria-label="Email address for newsletter"` to newsletter email input
- Added `aria-label="Subscribe to newsletter"` to Subscribe button
## Testing
- Verified aria-labels present in DOM inspector
- Tested with browser accessibility tree viewer
- Confirmed screen readers announce meaningful descriptions
## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included