### PR TITLE
Fix: Map Leaflet Overlap on Top Navbar

### DIFF
--- a/map.css
+++ b/map.css
@@ -177,7 +177,7 @@ body{
   border-bottom:
     1px solid var(--border);
 
-  z-index:999;
+  z-index:1010;
 }
 
 .search-bar{


### PR DESCRIPTION
a## Related Issue
Closes #1690 

## Summary
This pull request fixes a visual bug on the map components page where the Leaflet map zoom control buttons (+ / -) were overlapping the top navigation bar. The issue was caused by Leaflet's default high `z-index` overriding the navbar's stacking context.

## Changes Made
- Increased the `z-index` value of the top navbar container to ensure it stays on top of all map overlay elements.
- Maintained proper stacking hierarchy so map controls smoothly slide underneath the navbar during page scroll.

## Testing
- Opened the map components page locally.
- Scrolled the page vertically to bring the map cards directly under the sticky top navbar.
- Verified that the zoom controls no longer bleed into or render on top of the navbar background.

## Screenshots
<img width="1896" height="1078" alt="image" src="https://github.com/user-attachments/assets/57cedc36-6d82-44c9-bc3b-ddf084e8a791" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
