### PR TITLE
fix: resolve Font Awesome icon rendering issue in layout

### DIFF
--- a/buttons.css
+++ b/buttons.css
@@ -17,6 +17,18 @@
   pointer-events: none;
 }
 
+.fa-solid, .fas {
+  font-family: "Font Awesome 6 Free" !important;
+  font-weight: 900;
+}
+.fa-regular, .far {
+  font-family: "Font Awesome 6 Free" !important;
+  font-weight: 400;
+}
+.fa-brands, .fab {
+  font-family: "Font Awesome 6 Brands" !important;
+}
+
 /* ============================================================
    HERO PREVIEW — floating button animation
    ============================================================ */


### PR DESCRIPTION
a## Related Issue
Closes #1707 

## Summary
This pull request fixes the bug where Font Awesome icons across the layout were failing to render (showing up as blank spaces or empty boxes). The issue was caused by a cascading typography override from our custom stylesheets that globally stripped Font Awesome's native `font-family` property. Explicitly declaring the correct font families with `!important` rules inside the CSS layer resolves this conflict.

## Changes Made
- Added targeted font-family rules to `buttons.css` to safeguard icon rendering.

- Forced `.fa-solid` and `.fas` to prioritize "Font Awesome 6 Free" with a 900 weight.

- Forced `.fa-regular` and `.far` to prioritize "Font Awesome 6 Free" with a 400 weight.

- Forced `.fa-brands` and `.fab` to map correctly to "Font Awesome 6 Brands".

## Testing
- Launched button.html locally across web browsers.

- Verified that all navigation icons in the sidebar, utility icons in the header, status badges, and action buttons now load and render correctly.

- Inspected the computed styles in the developer console to verify that global font rule declarations no longer trample the icon styles.

## Screenshots
<img width="1901" height="1078" alt="image" src="https://github.com/user-attachments/assets/0f44a10d-57b7-4902-b465-a16b64d74226" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
