### PR TITLE
feat: Add custom color creator & picker to the Colors page

### DIFF
--- a/color.html
+++ b/color.html
@@ -106,6 +106,69 @@
     </div>
   </div>
 
+  <!-- ===== CUSTOM COLOR CREATOR ===== -->
+  <section class="custom-creator-section">
+    <div class="section-header-row">
+      <h2 class="color-section-title">🎨 Custom Color Creator</h2>
+      <span class="section-count">Pick & Copy</span>
+    </div>
+
+    <div class="creator-wrapper">
+
+      <!-- LEFT CARD: picker + values -->
+      <div class="creator-card">
+        <div class="creator-left">
+          <div class="creator-preview" id="creatorPreview" style="background:#eb6835;"></div>
+          <input type="color" id="colorPicker" value="#eb6835">
+          <label for="colorPicker" class="picker-label">
+            <i class="fa-solid fa-pen-nib"></i> Open Picker
+          </label>
+          <button class="save-color-btn" onclick="saveToSessionPalette()">
+            <i class="fa-solid fa-plus"></i> Add to Palette
+          </button>
+        </div>
+
+        <div class="creator-right">
+          <div class="creator-val-row">
+            <span class="creator-val-label">Hex:</span>
+            <span class="creator-val-output" id="outHex">#eb6835</span>
+            <button class="creator-copy-btn" onclick="copyText(document.getElementById('outHex').textContent, this)">
+              <i class="fa-regular fa-copy"></i> Copy
+            </button>
+          </div>
+          <div class="creator-val-row">
+            <span class="creator-val-label">RGB:</span>
+            <span class="creator-val-output" id="outRgb">rgb(235, 104, 53)</span>
+            <button class="creator-copy-btn" onclick="copyText(document.getElementById('outRgb').textContent, this)">
+              <i class="fa-regular fa-copy"></i> Copy
+            </button>
+          </div>
+          <div class="creator-val-row">
+            <span class="creator-val-label">HSL:</span>
+            <span class="creator-val-output" id="outHsl">hsl(20, 82%, 56%)</span>
+            <button class="creator-copy-btn" onclick="copyText(document.getElementById('outHsl').textContent, this)">
+              <i class="fa-regular fa-copy"></i> Copy
+            </button>
+          </div>
+
+          <div class="contrast-row">
+            <span class="contrast-chip fail" id="contrastWhite">AA × on White</span>
+            <span class="contrast-chip pass" id="contrastBlack">AA ✓ on Black</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT CARD: palette -->
+      <div class="palette-panel" id="palettePanel">
+        <h3 class="palette-panel-title">Color Palette</h3>
+        <div class="session-palette" id="sessionPalette">
+          <div class="empty-palette-msg">No colors yet.<br>Pick one and click Add.</div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
   <!-- ===== TRENDING COLORS ===== -->
   <section class="color-section" data-section="trending">
     <div class="section-header-row">
@@ -588,6 +651,92 @@
       s.style.display = (sec === 'all' || s.dataset.section === sec) ? '' : 'none';
     });
   }
+
+  /* ===== Custom Color Creator ===== */
+  const picker = document.getElementById('colorPicker');
+
+  picker.addEventListener('input', updateCreator);
+  picker.addEventListener('change', updateCreator);
+
+  function updateCreator() {
+    const hex = picker.value;
+    document.getElementById('creatorPreview').style.background = hex;
+    document.getElementById('outHex').textContent = hex;
+    document.getElementById('outRgb').textContent = hexToRgb(hex);
+    document.getElementById('outHsl').textContent = hexToHsl(hex);
+    updateContrast(hex);
+  }
+
+  function hexToRgb(hex) {
+    const r = parseInt(hex.slice(1,3),16);
+    const g = parseInt(hex.slice(3,5),16);
+    const b = parseInt(hex.slice(5,7),16);
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+
+  function hexToHsl(hex) {
+    let r = parseInt(hex.slice(1,3),16)/255;
+    let g = parseInt(hex.slice(3,5),16)/255;
+    let b = parseInt(hex.slice(5,7),16)/255;
+    const max = Math.max(r,g,b), min = Math.min(r,g,b);
+    let h, s, l = (max+min)/2;
+    if (max === min) { h = s = 0; }
+    else {
+      const d = max - min;
+      s = l > 0.5 ? d/(2-max-min) : d/(max+min);
+      switch(max){
+        case r: h=((g-b)/d+(g<b?6:0))/6; break;
+        case g: h=((b-r)/d+2)/6; break;
+        case b: h=((r-g)/d+4)/6; break;
+      }
+    }
+    return `hsl(${Math.round(h*360)}, ${Math.round(s*100)}%, ${Math.round(l*100)}%)`;
+  }
+
+  function getLuminance(hex) {
+    return [1,3,5].map(i => {
+      const c = parseInt(hex.slice(i,i+2),16)/255;
+      return c <= 0.03928 ? c/12.92 : Math.pow((c+0.055)/1.055,2.4);
+    }).reduce((acc,c,i) => acc + c * [0.2126,0.7152,0.0722][i], 0);
+  }
+
+  function contrastRatio(hex, bg) {
+    const L1 = getLuminance(hex), L2 = getLuminance(bg);
+    return (Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05);
+  }
+
+  function updateContrast(hex) {
+    const vsWhite = contrastRatio(hex, '#ffffff');
+    const vsBlack = contrastRatio(hex, '#000000');
+    const wEl = document.getElementById('contrastWhite');
+    const bEl = document.getElementById('contrastBlack');
+    wEl.textContent = vsWhite >= 4.5 ? `AA ✓ on White (${vsWhite.toFixed(1)}:1)` : `AA ✗ on White (${vsWhite.toFixed(1)}:1)`;
+    wEl.className = 'contrast-chip ' + (vsWhite >= 4.5 ? 'pass' : 'fail');
+    bEl.textContent = vsBlack >= 4.5 ? `AA ✓ on Black (${vsBlack.toFixed(1)}:1)` : `AA ✗ on Black (${vsBlack.toFixed(1)}:1)`;
+    bEl.className = 'contrast-chip ' + (vsBlack >= 4.5 ? 'pass' : 'fail');
+  }
+
+  function saveToSessionPalette() {
+    const hex = picker.value;
+    const palette = document.getElementById('sessionPalette');
+
+    const msg = palette.querySelector('.empty-palette-msg');
+    if (msg) msg.remove();
+
+    const swatch = document.createElement('div');
+    swatch.className = 'session-swatch';
+    swatch.style.background = hex;
+    swatch.title = hex;
+    swatch.innerHTML = `<span class="swatch-check">✓</span>`;
+    swatch.onclick = () => {
+      copyText(hex, null);
+      swatch.classList.add('just-copied');
+      setTimeout(() => swatch.classList.remove('just-copied'), 1500);
+    };
+    palette.appendChild(swatch);
+  }
+
+  updateCreator(); // init on load
 
   /* Live search */
   function liveFilter(val) {

--- a/colors.css
+++ b/colors.css
@@ -139,6 +139,223 @@
 }
 .filter-search input::placeholder { color: #aaa; }
 
+/* ===== Custom Color Creator ===== */
+.custom-creator-section { margin-bottom: 3rem; }
+
+.creator-wrapper {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+/* LEFT CARD */
+.creator-card {
+  display: flex;
+  gap: 1.5rem;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border, #e8e6e1);
+  border-radius: 20px;
+  padding: 1.75rem;
+  align-items: center;
+  flex: 2;
+  min-width: 320px;
+  flex-wrap: wrap;
+}
+
+.creator-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.creator-preview {
+  width: 150px;
+  height: 150px;
+  border-radius: 16px;
+  transition: background 0.1s;
+  border: 1px solid rgba(0,0,0,0.08);
+  flex-shrink: 0;
+}
+
+#colorPicker {
+  width: 0; height: 0;
+  opacity: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.picker-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 22px;
+  background: #eb6835;
+  color: #fff;
+  border-radius: 12px;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  transition: opacity 0.2s;
+  width: 150px;
+  justify-content: center;
+  box-sizing: border-box;
+}
+.picker-label:hover { opacity: 0.88; }
+
+.save-color-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 22px;
+  border: 2px dashed #ccc;
+  border-radius: 12px;
+  background: none;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  color: #777;
+  transition: all 0.2s;
+  width: 150px;
+  box-sizing: border-box;
+}
+.save-color-btn:hover { border-color: #eb6835; color: #eb6835; }
+
+/* RIGHT SIDE: values */
+.creator-right {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 240px;
+}
+
+.creator-val-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--input-bg, #f5f4f2);
+  border-radius: 999px;
+  padding: 10px 16px;
+}
+
+.creator-val-label {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: #555;
+  width: 36px;
+  flex-shrink: 0;
+}
+
+.creator-val-output {
+  flex: 1;
+  font-family: 'Courier New', monospace;
+  font-size: 13px;
+  color: var(--text, #1a1a2e);
+}
+
+.creator-copy-btn {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 12px;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  color: #555;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.creator-copy-btn:hover { background: #eb6835; color: #fff; border-color: #eb6835; }
+
+.contrast-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 0 4px;
+}
+
+.contrast-chip {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  padding: 5px 14px;
+  border-radius: 999px;
+  font-weight: 500;
+}
+.contrast-chip.pass { background: #d4f5e9; color: #007a50; }
+.contrast-chip.fail { background: #fde8e8; color: #c0392b; }
+
+/* RIGHT CARD: palette panel */
+.palette-panel {
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border, #e8e6e1);
+  border-radius: 20px;
+  padding: 1.75rem;
+  flex: 1;
+  min-width: 200px;
+}
+
+.palette-panel-title {
+  font-family: 'Syne', sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text, #1a1a2e);
+  margin: 0 0 1rem;
+}
+
+.session-palette {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.empty-palette-msg {
+  grid-column: 1 / -1;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: #aaa;
+  text-align: center;
+  padding: 1.5rem 0;
+  line-height: 1.6;
+}
+
+.session-swatch {
+  aspect-ratio: 1;
+  border-radius: 14px;
+  cursor: pointer;
+  border: 1px solid rgba(0,0,0,0.08);
+  transition: transform 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+.session-swatch:hover { transform: scale(1.06); }
+.session-swatch .swatch-check {
+  font-size: 20px;
+  color: rgba(255,255,255,0.9);
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+.session-swatch:hover .swatch-check,
+.session-swatch.just-copied .swatch-check { opacity: 1; }
+
+/* Dark mode */
+.dark-mode .creator-card,
+.dark-mode .palette-panel { background: #1a1a2e; border-color: #2d2d44; }
+.dark-mode .creator-val-row { background: #0f0f1a; }
+.dark-mode .creator-val-output { color: #f0f0f0; }
+.dark-mode .creator-copy-btn { background: #1a1a2e; border-color: #444; color: #aaa; }
+.dark-mode .palette-panel-title { color: #f0f0f0; }
+
 /* ============================================================
    SECTION COMMON
    ============================================================ */


### PR DESCRIPTION
a## Related Issue
Closes #1750 

## Summary
Adds a **Custom Color Creator** section to the Colors page (`color.html`) that lets users pick any color and instantly copy its HEX, RGB, and HSL values. Includes a session palette panel, WCAG contrast checker, and dark mode support — all with zero new dependencies.

## Changes Made
- Added `Custom Color Creator` section to `color.html` between the filter bar and the Trending Colors section
- Implemented native `<input type="color">` picker with a styled label trigger (hides the default browser button)
- Added live HEX, RGB, and HSL readouts with one-click copy buttons, reusing the existing `copyText()` utility
- Added WCAG AA contrast checker that shows pass/fail ratio against both white and black backgrounds
- Added session palette panel (right card) where users can save picked colors; swatches show a ✓ on hover and copy the value on click
- Added all supporting CSS to `colors.css` with full dark mode support via `.dark-mode` overrides
- Added `hexToRgb()`, `hexToHsl()`, `getLuminance()`, `contrastRatio()`, `updateCreator()`, and `saveToSessionPalette()` JS helpers to the page script block
- Section uses no `class="color-section"` or `data-section` attribute so it is never hidden by the existing `filterSection()` or `liveFilter()` logic

## Testing
- Opened `color.html` locally in Chrome and Firefox
- Picked multiple colors and verified HEX, RGB, and HSL values update correctly in real time
- Clicked all three Copy buttons and confirmed the toast notification fires and clipboard content is correct
- Verified contrast chips update correctly (pass/fail) across light and mid-range colors
- Added several colors to the session palette and confirmed swatches render and copy on click
- Toggled dark mode and confirmed all creator and palette panel styles adapt correctly
- Clicked all existing filter buttons (Trending, Gradients, Palettes, Themed) and confirmed the creator section stays visible
- Tested on a narrow viewport to confirm `flex-wrap` kicks in and the layout stays usable

## Screenshots
<img width="1898" height="1078" alt="image" src="https://github.com/user-attachments/assets/851adf3d-d929-4c44-a869-5719e6c5535d" />
<img width="1555" height="513" alt="image" src="https://github.com/user-attachments/assets/d33d41f7-f5e5-430a-b519-dd426b39bcfa" />
<img width="1511" height="490" alt="image" src="https://github.com/user-attachments/assets/15020996-81e2-426c-bb55-4476574543dd" />


## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
