### PR TITLE
fix: header-link in contributors page

### DIFF
--- a/contributors.css
+++ b/contributors.css
@@ -67,6 +67,10 @@ body {
   font-family: var(--heading);
 }
 
+.logo-link {
+  text-decoration: none;
+}
+
 .nav-right {
 
   display: flex;

--- a/contributorss.html
+++ b/contributorss.html
@@ -51,9 +51,11 @@
   <!-- ================= NAVBAR ================= -->
   <header class="navbar">
 
-    <div class="logo">
-      ⬡ UIverse
-    </div>
+    <a href="index.html" class="logo-link">
+      <div class="logo">
+        ⬡ UIverse
+      </div>
+    </a>
 
     <div class="nav-right">
 


### PR DESCRIPTION
a## Related Issue
Closes #1829 

## Summary
This pull request fixes a navigation issue on the Project Contributors page in which the "Ulverse" header logo was rendered as static text. It adds a hyperlink to the logo, allowing users to intuitively navigate back to the main project home page without relying on browser controls.

## Changes Made
- Wrapped the "Ulverse" logo/title component in an anchor tag (`<a>` or the project's router link component).
- Configured the link destination (`href`) to point to the root home page (`index.html`).
- Verified that hover states and pointer cursors behave correctly for the newly linked element.

## Testing
- Launched the development server locally.
- Navigated to the Project Contributors page.
- Hovered over and clicked the "Ulverse" logo in the header to confirm it successfully routes back to the home page.

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
