### PR TITLE
fix: Broken audio source placeholder

### DIFF
--- a/audioplayer/song.html
+++ b/audioplayer/song.html
@@ -19,7 +19,7 @@
     <p>Artist Name</p>
 
     <audio id="audio">
-      <source src="" type="audio/mp3">
+      <source src="https://www.w3schools.com/html/horse.mp3" type="audio/mpeg">
     </audio>
 
     <input type="range" id="progressBar" value="0">


### PR DESCRIPTION
Fixed the broken audio placeholder in song.html by replacing the empty source with a valid playable sample and correcting the MIME type to `audio/mpeg`. That gives the Play button an actual media file to load instead of a no-op source.

I also verified the rendered page and confirmed the audio element now resolves to `https://www.w3schools.com/html/horse.mp3` with the expected type.

closes #1719