### PR TITLE
fix: resolve Font Awesome icons not rendering due to global font-family override

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -132,6 +132,19 @@
 .sidebar-backdrop.visible {
   display: block;
 }
+
+.fa-solid, .fas {
+  font-family: "Font Awesome 6 Free" !important;
+  font-weight: 900;
+}
+.fa-regular, .far {
+  font-family: "Font Awesome 6 Free" !important;
+  font-weight: 400;
+}
+.fa-brands, .fab {
+  font-family: "Font Awesome 6 Brands" !important;
+}
+
 /* ============================================================
    HERO PREVIEW — mini card widget
    ============================================================ */


### PR DESCRIPTION
a## Related Issue
Closes #1851 

## Summary
Fixed Font Awesome icons not rendering due to global font-family styles overriding the FA font declarations.


## Changes Made
- Added explicit `font-family` overrides for `.fa-solid`, `.fa-regular`, and `.fa-brands` classes
- Applied `!important` to ensure FA font declarations are not clobbered by global font styles (Syne / DM Sans)

## Testing
- Opened the Cards page locally and verified all Font Awesome icons render correctly across Profile, Content, Social, and Commerce card components
- Checked icon rendering in both light and dark mode
- Confirmed no regression on text fonts (Syne, DM Sans) elsewhere on the page

## Screenshots
<img width="1895" height="1078" alt="image" src="https://github.com/user-attachments/assets/acfa4f6f-76ae-4937-bfcf-2203aff0edd2" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
