### PR TITLE
feat(error-pages): add 429, Location Denied, and 410 Gone error components

### DIFF
--- a/error.css
+++ b/error.css
@@ -179,6 +179,11 @@ body{
   color: #64748b;
 }
 
+.error-icon-code {
+  display: flex;
+  gap: 16px;
+}
+
 .component-preview {
   height: 300px; /* Taller for error screens */
   background: #0f172a;
@@ -746,5 +751,158 @@ body{
   0% { transform: translateY(0); filter: brightness(1); }
   50% { transform: translateY(-6px); filter: brightness(1.2); }
   100% { transform: translateY(0); filter: brightness(1); }
+}
+
+/* 11. 429 Too Many Requests */
+.err-429 {
+  background: linear-gradient(135deg, #1a1040 0%, #0f0a2e 100%) !important;
+  border: 1px solid rgba(99, 102, 241, 0.25) !important;
+  box-shadow: 0 8px 32px rgba(99, 102, 241, 0.1);
+}
+.err-429 .icon-wrap {
+  font-size: 46px;
+  color: #818cf8;
+  margin-bottom: 10px;
+  animation: throttle-shake 1.5s ease-in-out infinite;
+}
+.err-429 .error-code {
+  background: linear-gradient(90deg, #818cf8, #c084fc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.err-429 .error-title { color: #e0e7ff; font-family: "Syne", sans-serif; font-weight: 700; }
+.err-429 .rate-badges {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+.err-429 .badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 20px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+.err-429 .badge.active {
+  background: rgba(129, 140, 248, 0.25);
+  color: #c7d2fe;
+  border-color: rgba(129, 140, 248, 0.4);
+}
+.err-429 .error-btn {
+  background: linear-gradient(135deg, #6366f1, #818cf8);
+  color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+.err-429 .error-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(99, 102, 241, 0.45);
+}
+@keyframes throttle-shake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-4px); }
+  40% { transform: translateX(4px); }
+  60% { transform: translateX(-3px); }
+  80% { transform: translateX(3px); }
+}
+
+/* 12. Location Access Denied */
+.err-location {
+  background: linear-gradient(135deg, #0d2318 0%, #071a10 100%) !important;
+  border: 1px solid rgba(34, 197, 94, 0.2) !important;
+  box-shadow: 0 8px 32px rgba(34, 197, 94, 0.08);
+}
+.err-location .icon-wrap {
+  font-size: 44px;
+  color: #4ade80;
+  margin-bottom: 12px;
+  animation: pin-drop 3s ease-in-out infinite;
+}
+.err-location .error-title { color: #bbf7d0; font-family: "Syne", sans-serif; font-weight: 700; }
+.err-location .coords {
+  font-size: 11px;
+  font-family: monospace;
+  color: #4ade80;
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.15);
+  border-radius: 6px;
+  padding: 6px 14px;
+  margin-bottom: 12px;
+  letter-spacing: 1.5px;
+}
+.err-location .coords span { color: #6b7280; }
+.err-location .error-btn {
+  background: transparent;
+  color: #4ade80;
+  border: 1px solid rgba(74, 222, 128, 0.4);
+  border-radius: 8px;
+}
+.err-location .error-btn:hover {
+  background: rgba(74, 222, 128, 0.1);
+  border-color: #4ade80;
+  transform: translateY(-2px);
+}
+@keyframes pin-drop {
+  0%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-10px); }
+  60% { transform: translateY(0); }
+  70% { transform: translateY(-4px); }
+  85% { transform: translateY(0); }
+}
+
+/* 13. 410 Link / Token Expired */
+.err-410 {
+  background: linear-gradient(135deg, #1c1407 0%, #130e04 100%) !important;
+  border: 1px solid rgba(251, 191, 36, 0.18) !important;
+  box-shadow: 0 8px 32px rgba(251, 191, 36, 0.06);
+}
+.err-410 .icon-wrap {
+  font-size: 44px;
+  color: #fbbf24;
+  margin-bottom: 10px;
+  animation: fade-flicker 4s ease-in-out infinite;
+}
+.err-410 .error-title { color: #fef3c7; font-family: "Syne", sans-serif; font-weight: 700; }
+.err-410 .token-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.err-410 .token-seg {
+  height: 5px;
+  border-radius: 3px;
+  background: rgba(251, 191, 36, 0.15);
+}
+.err-410 .token-seg:nth-child(1) { width: 40px; }
+.err-410 .token-seg:nth-child(2) { width: 32px; background: rgba(251, 191, 36, 0.45); }
+.err-410 .token-seg:nth-child(3) { width: 22px; background: rgba(251, 191, 36, 0.08); }
+.err-410 .token-seg:nth-child(4) { width: 48px; }
+.err-410 .token-label {
+  font-size: 10px;
+  color: #78350f;
+  letter-spacing: 2px;
+  font-family: monospace;
+  margin-bottom: 12px;
+}
+.err-410 .error-btn {
+  background: rgba(251, 191, 36, 0.1);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  border-radius: 8px;
+}
+.err-410 .error-btn:hover {
+  background: rgba(251, 191, 36, 0.2);
+  color: #fef3c7;
+  transform: translateY(-2px);
+}
+@keyframes fade-flicker {
+  0%, 100% { opacity: 1; filter: brightness(1); }
+  35% { opacity: 0.5; filter: brightness(0.6); }
+  38% { opacity: 1; }
+  74% { opacity: 0.7; filter: brightness(0.7); }
+  77% { opacity: 1; }
 }
 

--- a/error.html
+++ b/error.html
@@ -542,6 +542,87 @@
       </div>
     </div>
 
+    <!-- 11. 429 TOO MANY REQUESTS -->
+    <div class="error-card">
+      <div class="error-info">
+        <h2>429 Too Many Requests</h2>
+        <p>Rate-limit screen with throttle animation and cooldown badges.</p>
+      </div>
+      <div class="component-preview" id="preview-11">
+        <div class="error-screen err-429">
+          <div class="error-icon-code">
+            <div class="icon-wrap"><i class="fa-solid fa-gauge-high"></i></div>
+            <div class="error-code" style="font-size:48px;">429</div>
+          </div>
+          <div class="error-title">Too Many Requests</div>
+          <div class="rate-badges">
+            <span class="badge active">Rate Limited</span>
+            <span class="badge">Cooldown Active</span>
+          </div>
+          <div class="error-desc">You've sent too many requests in a short time. Please wait a moment before trying again.</div>
+          <button class="error-btn"><i class="fa-solid fa-rotate-right"></i> Retry Later</button>
+        </div>
+      </div>
+      <div class="card-actions">
+        <button class="copy-btn" data-target="preview-11">
+          <i class="fa-regular fa-copy"></i> <span>Copy Code</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- 12. LOCATION ACCESS DENIED -->
+    <div class="error-card">
+      <div class="error-info">
+        <h2>Location Access Denied</h2>
+        <p>Geo-permission blocked state with a redacted coordinates display.</p>
+      </div>
+      <div class="component-preview" id="preview-12">
+        <div class="error-screen err-location">
+          <div class="icon-wrap"><i class="fa-solid fa-location-dot"></i></div>
+          <div class="error-title">Location Access Denied</div>
+          <div class="coords"><span>LAT</span> ██.████  <span>LNG</span> ██.████</div>
+          <div class="error-desc">Your browser has blocked location access. Enable permissions to use location-based features.</div>
+          <button class="error-btn">Enable Location</button>
+        </div>
+      </div>
+      <div class="card-actions">
+        <button class="copy-btn" data-target="preview-12">
+          <i class="fa-regular fa-copy"></i> <span>Copy Code</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- 13. 410 LINK / TOKEN EXPIRED -->
+    <div class="error-card">
+      <div class="error-info">
+        <h2>Link / Token Expired</h2>
+        <p>Amber-toned expiry page with a decaying token visualizer and flicker animation.</p>
+      </div>
+      <div class="component-preview" id="preview-13">
+        <div class="error-screen err-410">
+          <div class="error-icon-code">
+            <div class="icon-wrap"><i class="fa-solid fa-link-slash"></i></div>
+            <div class="error-code" style="font-size:48px; color:#92400e;">410</div>
+          </div>
+          <div class="error-title">Link Expired</div>
+          <div class="token-row">
+            <div class="token-seg"></div>
+            <div class="token-seg"></div>
+            <div class="token-seg gone"></div>
+            <div class="token-seg"></div>
+          </div>
+          <div class="token-label">TOKEN EXPIRED</div>
+          <div class="error-desc">This link is no longer valid. It may have expired or already been used.</div>
+          <button class="error-btn">Request New Link</button>
+        </div>
+      </div>
+      <div class="card-actions">
+        <button class="copy-btn" data-target="preview-13">
+          <i class="fa-regular fa-copy"></i> <span>Copy Code</span>
+        </button>
+      </div>
+    </div>
+
   </section>
 
   <!-- ================= FOOTER ================= -->


### PR DESCRIPTION
a## Related Issue
Closes #1977 

## Summary
Adds three new error page components to the UIverse error pages section, following the existing design system and animation patterns.

## Changes Made
- Added **429 Too Many Requests** — indigo-themed rate limit screen with shake animation and cooldown badge indicators
- Added **Location Access Denied** — green-themed geo-permission blocked state with pin-drop animation and redacted coordinates display
- Added **410 Link / Token Expired (Gone)** — amber-themed expiry screen with flicker animation and a decaying token segment visualizer
- Added corresponding CSS for all three components in `error.css` including keyframe animations (`throttle-shake`, `pin-drop`, `fade-flicker`)

## Testing
- Opened `error.html` locally in browser and confirmed all three components render correctly within their card containers
- Verified animations play as expected (shake on 429, bounce on location, flicker on 410)
- Confirmed Copy Code buttons copy the correct inner HTML for each new preview
- Checked responsive layout at 768px and 992px breakpoints — grid collapses correctly

## Screenshots
<img width="1900" height="1078" alt="image" src="https://github.com/user-attachments/assets/884972db-a6c1-4419-b5e4-7cb8b26d2f67" />
<img width="1898" height="1078" alt="image" src="https://github.com/user-attachments/assets/7c4f3335-5563-47f6-8842-e6ab273e2e2d" />


## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
