### PR TITLE
Component “Download as Zip” Export

### DIFF
--- a/data/meta/export-map.json
+++ b/data/meta/export-map.json
@@ -1,0 +1,102 @@
+{
+  "defaults": {
+    "fileNames": {
+      "html": "component.html",
+      "css": "component.css",
+      "js": "component.js",
+      "readme": "README.md"
+    },
+    "ignoreStylesheets": [
+      "style.css",
+      "playground.css",
+      "command-palette.css",
+      "css/main.css",
+      "css/url-state.css"
+    ],
+    "ignoreScripts": [
+      "js/",
+      "script.js",
+      "playground.js",
+      "js/bootstrap.js"
+    ],
+    "readmeTemplate": "# {componentTitle}\n\nThis export was generated from {pagePath}.\n\nIncluded files:\n- component.html\n- component.css{hasJsLine}\n\nUsage:\n1. Open component.html in a browser or app shell.\n2. Link component.css in the same folder.\n{jsUsageLine}\n\nNotes:\n- This zip uses the active code block and the page-local stylesheet/script.\n- Keep the filenames if you want a drop-in export."
+  },
+  "components": {
+    "button": {
+      "title": "Buttons",
+      "path": "button.html",
+      "stylesheets": ["button.css"]
+    },
+    "cards": {
+      "title": "Cards",
+      "path": "cards.html",
+      "stylesheets": ["cards.css"]
+    },
+    "form": {
+      "title": "Forms",
+      "path": "form.html",
+      "stylesheets": ["form.css"]
+    },
+    "alerts": {
+      "title": "Alerts",
+      "path": "alerts.html",
+      "stylesheets": ["alerts.css"]
+    },
+    "badges": {
+      "title": "Badges",
+      "path": "badges.html",
+      "stylesheets": ["badges.css"]
+    },
+    "navbar": {
+      "title": "Navbar",
+      "path": "navbar.html",
+      "stylesheets": ["navbar.css"]
+    },
+    "footer": {
+      "title": "Footer",
+      "path": "footer.html",
+      "stylesheets": ["footer.css"]
+    },
+    "color": {
+      "title": "Color System",
+      "path": "color.html",
+      "stylesheets": ["colors.css"]
+    },
+    "pricing": {
+      "title": "Pricing",
+      "path": "pricing.html",
+      "stylesheets": ["pricing.css"]
+    },
+    "toggles": {
+      "title": "Toggles",
+      "path": "toggles.html",
+      "stylesheets": ["toggles.css"]
+    },
+    "settings": {
+      "title": "Settings",
+      "path": "settings.html",
+      "stylesheets": ["settings.css"]
+    },
+    "calendar": {
+      "title": "Calendar Components",
+      "path": "calendar.html",
+      "stylesheets": ["calendar.css"]
+    },
+    "calender": {
+      "title": "Calendar Components",
+      "path": "Calender.html",
+      "stylesheets": ["calendar.css"]
+    },
+    "accordion": {
+      "title": "Accordion",
+      "path": "accordion/acc.html",
+      "stylesheets": ["accordion/acc.css"],
+      "scripts": ["accordion/acc.js"]
+    },
+    "compare": {
+      "title": "Compare",
+      "path": "compare.html",
+      "stylesheets": ["compare.css"]
+    }
+  }
+}

--- a/js/features/code-tools.js
+++ b/js/features/code-tools.js
@@ -4,6 +4,12 @@
  */
 
 const CodeTools = {
+  _state: {
+    exportConfig: null,
+    exportConfigPromise: null,
+    jsZipPromise: null
+  },
+
   /**
    * Copy text using the Clipboard API when available, otherwise fall back to a hidden textarea.
    * @param {string} text
@@ -124,6 +130,331 @@ const CodeTools = {
       });
   },
 
+  _normalizePath(value) {
+    return String(value || '').split('?')[0].split('#')[0];
+  },
+
+  _getCurrentPagePath() {
+    return this._normalizePath(window.location.pathname || '');
+  },
+
+  _getPageSlug() {
+    const path = this._getCurrentPagePath();
+    const lastSegment = path.split('/').filter(Boolean).pop() || 'index.html';
+    return lastSegment.replace(/\.html?$/i, '').toLowerCase();
+  },
+
+  _loadScript(src) {
+    return new Promise((resolve, reject) => {
+      if (document.querySelector(`script[data-export-lib="${src}"]`)) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = true;
+      script.dataset.exportLib = src;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  },
+
+  _loadJSZip() {
+    if (window.JSZip) {
+      return Promise.resolve(window.JSZip);
+    }
+
+    if (!this._state.jsZipPromise) {
+      this._state.jsZipPromise = this._loadScript('https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js')
+        .then(() => window.JSZip)
+        .catch((error) => {
+          this._state.jsZipPromise = null;
+          throw error;
+        });
+    }
+
+    return this._state.jsZipPromise;
+  },
+
+  _loadExportConfig() {
+    if (this._state.exportConfig) {
+      return Promise.resolve(this._state.exportConfig);
+    }
+
+    if (!this._state.exportConfigPromise) {
+      this._state.exportConfigPromise = fetch('data/meta/export-map.json', { cache: 'no-store' })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((json) => {
+          this._state.exportConfig = json && typeof json === 'object' ? json : {};
+          return this._state.exportConfig;
+        })
+        .catch(() => {
+          this._state.exportConfig = {
+            defaults: {
+              fileNames: {
+                html: 'component.html',
+                css: 'component.css',
+                js: 'component.js',
+                readme: 'README.md'
+              },
+              ignoreStylesheets: ['style.css', 'playground.css', 'command-palette.css', 'css/main.css', 'css/url-state.css'],
+              ignoreScripts: ['js/', 'script.js', 'playground.js', 'js/bootstrap.js'],
+              readmeTemplate: [
+                '# {componentTitle}',
+                '',
+                'This export was generated from {pagePath}.',
+                '',
+                'Included files:',
+                '- component.html',
+                '- component.css{hasJsLine}',
+                '',
+                'Usage:',
+                '1. Open component.html in a browser or app shell.',
+                '2. Link component.css in the same folder.',
+                '{jsUsageLine}',
+                '',
+                'Notes:',
+                '- This package uses the currently active code block and the page-local stylesheet/script.',
+                '- Keep the filenames if you want a drop-in export.'
+              ].join('\n')
+            },
+            components: {}
+          };
+          return this._state.exportConfig;
+        });
+    }
+
+    return this._state.exportConfigPromise;
+  },
+
+  _isIgnoredAsset(href, ignoreList) {
+    const normalized = this._normalizePath(href).toLowerCase();
+    return (ignoreList || []).some((item) => normalized === item.toLowerCase() || normalized.endsWith('/' + item.toLowerCase()));
+  },
+
+  _collectLocalStylesheets(ignoreList, preferred) {
+    const links = Array.from(document.querySelectorAll('link[rel="stylesheet"][href]'));
+    const hrefs = links.map((link) => this._normalizePath(link.getAttribute('href'))).filter(Boolean);
+    const local = hrefs.filter((href) => !/^https?:\/\//i.test(href) && !href.startsWith('data:') && !this._isIgnoredAsset(href, ignoreList));
+
+    if (preferred && preferred.length > 0) {
+      const preferredMatch = preferred
+        .map((item) => this._normalizePath(item).toLowerCase())
+        .filter(Boolean)
+        .map((pattern) => local.find((href) => href.toLowerCase().endsWith(pattern)) || null)
+        .find(Boolean);
+
+      if (preferredMatch) {
+        return [preferredMatch];
+      }
+    }
+
+    return local;
+  },
+
+  _collectLocalScripts(ignoreList, preferred) {
+    const scripts = Array.from(document.querySelectorAll('script[src]'));
+    const hrefs = scripts.map((script) => this._normalizePath(script.getAttribute('src'))).filter(Boolean);
+    const local = hrefs.filter((href) => !/^https?:\/\//i.test(href) && !href.startsWith('data:') && !this._isIgnoredAsset(href, ignoreList));
+
+    if (preferred && preferred.length > 0) {
+      const preferredMatch = preferred
+        .map((item) => this._normalizePath(item).toLowerCase())
+        .filter(Boolean)
+        .map((pattern) => local.find((href) => href.toLowerCase().endsWith(pattern)) || null)
+        .find(Boolean);
+
+      if (preferredMatch) {
+        return [preferredMatch];
+      }
+    }
+
+    return local;
+  },
+
+  _getExportProfile() {
+    const slug = this._getPageSlug();
+    const title = (document.querySelector('main h1, .section-title, .component-card h3, h1')?.textContent || document.title || slug).trim();
+
+    const config = this._state.exportConfig || {};
+    const defaults = config.defaults || {};
+    const componentMap = config.components || {};
+    const entry = componentMap[slug] || componentMap[this._getCurrentPagePath()] || componentMap[document.body?.dataset?.componentId] || null;
+
+    const ignoreStylesheets = [...(defaults.ignoreStylesheets || [])];
+    const ignoreScripts = [...(defaults.ignoreScripts || [])];
+
+    if (entry && Array.isArray(entry.ignoreStylesheets)) ignoreStylesheets.push(...entry.ignoreStylesheets);
+    if (entry && Array.isArray(entry.ignoreScripts)) ignoreScripts.push(...entry.ignoreScripts);
+
+    const stylesheetCandidates = entry && Array.isArray(entry.stylesheets) && entry.stylesheets.length > 0
+      ? entry.stylesheets
+      : this._collectLocalStylesheets(ignoreStylesheets, entry && Array.isArray(entry.preferredStylesheets) ? entry.preferredStylesheets : []);
+
+    const scriptCandidates = entry && Array.isArray(entry.scripts) && entry.scripts.length > 0
+      ? entry.scripts
+      : this._collectLocalScripts(ignoreScripts, entry && Array.isArray(entry.preferredScripts) ? entry.preferredScripts : []);
+
+    return {
+      componentId: slug,
+      componentTitle: entry?.title || title,
+      pagePath: entry?.path || this._getCurrentPagePath(),
+      fileNames: Object.assign({
+        html: 'component.html',
+        css: 'component.css',
+        js: 'component.js',
+        readme: 'README.md'
+      }, defaults.fileNames || {}, entry?.fileNames || {}),
+      stylesheetCandidates,
+      scriptCandidates,
+      readmeTemplate: entry?.readmeTemplate || defaults.readmeTemplate || '',
+      htmlLabel: entry?.htmlLabel || 'component.html'
+    };
+  },
+
+  _readCodeBlock(id) {
+    const element = getElement(id);
+    if (!element) return '';
+
+    return (element.tagName === 'TEXTAREA' || element.tagName === 'INPUT')
+      ? element.value
+      : element.innerText;
+  },
+
+  async _fetchAssetText(assetPath) {
+    if (!assetPath) return '';
+
+    const resolved = new URL(assetPath, document.baseURI).href;
+    const response = await fetch(resolved, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${assetPath}`);
+    }
+    return response.text();
+  },
+
+  _buildReadme(profile, hasJs) {
+    const template = String(profile.readmeTemplate || '');
+    const lines = template.split('\n');
+    const rendered = lines.map((line) => {
+      return line
+        .replace(/\{componentTitle\}/g, profile.componentTitle)
+        .replace(/\{pagePath\}/g, profile.pagePath)
+        .replace(/\{hasJsLine\}/g, hasJs ? '\n- component.js' : '')
+        .replace(/\{jsUsageLine\}/g, hasJs ? '3. Link component.js if the export includes behavior.' : '3. No JavaScript file was detected for this component.');
+    }).join('\n');
+
+    return rendered.replace(/\n\n\n+/g, '\n\n').trim() + '\n';
+  },
+
+  _downloadBlob(blob, filename) {
+    if (window.navigator && typeof window.navigator.msSaveOrOpenBlob === 'function') {
+      window.navigator.msSaveOrOpenBlob(blob, filename);
+      return;
+    }
+
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.rel = 'noopener';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+
+    setTimeout(() => URL.revokeObjectURL(url), 1500);
+  },
+
+  _injectExportButtons() {
+    document.querySelectorAll('.actions').forEach((actions) => {
+      if (actions.dataset.exportButtonInjected === '1') return;
+
+      const copyButton = actions.querySelector('button[onclick*="copyCode"]');
+      const toggleButton = actions.querySelector('button[onclick*="toggleCode"]');
+      const referenceButton = copyButton || toggleButton;
+      const onclick = referenceButton ? (referenceButton.getAttribute('onclick') || '') : '';
+      const match = onclick.match(/['"]([^'"]+)['"]/);
+      const codeId = match ? match[1] : '';
+      if (!codeId) return;
+
+      if (actions.querySelector('button[onclick*="exportCode"]')) {
+        actions.dataset.exportButtonInjected = '1';
+        return;
+      }
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'export-btn';
+      button.setAttribute('aria-label', 'Export component as zip');
+      button.setAttribute('title', 'Download as Zip');
+      button.setAttribute('onclick', `exportCode('${codeId}', this)`);
+      button.innerHTML = '<i class="fa-solid fa-file-zipper"></i> Export';
+
+      if (copyButton && copyButton.nextSibling) {
+        actions.insertBefore(button, copyButton.nextSibling);
+      } else {
+        actions.appendChild(button);
+      }
+
+      actions.dataset.exportButtonInjected = '1';
+    });
+  },
+
+  async exportCode(id, btn) {
+    const button = btn || null;
+    const originalText = button ? button.innerHTML : '';
+
+    try {
+      if (button) {
+        button.disabled = true;
+        button.innerHTML = 'Exporting...';
+      }
+
+      const [profile, JSZip] = await Promise.all([
+        this._loadExportConfig().then(() => this._getExportProfile()),
+        this._loadJSZip()
+      ]);
+
+      const html = this._readCodeBlock(id).trim();
+      const cssPath = profile.stylesheetCandidates[0] || '';
+      const jsPath = profile.scriptCandidates[0] || '';
+      const [css, js] = await Promise.all([
+        cssPath ? this._fetchAssetText(cssPath).catch(() => '') : Promise.resolve(''),
+        jsPath ? this._fetchAssetText(jsPath).catch(() => '') : Promise.resolve('')
+      ]);
+
+      const zip = new JSZip();
+      zip.file(profile.fileNames.html || 'component.html', html || '<!-- No component HTML found -->\n');
+      zip.file(profile.fileNames.css || 'component.css', css || '/* No component stylesheet detected */\n');
+
+      if (js && js.trim()) {
+        zip.file(profile.fileNames.js || 'component.js', js);
+      }
+
+      const readme = this._buildReadme(profile, Boolean(js && js.trim()));
+      zip.file(profile.fileNames.readme || 'README.md', readme);
+
+      const blob = await zip.generateAsync({ type: 'blob' });
+      const filename = `${profile.componentId || 'component'}-export.zip`;
+      this._downloadBlob(blob, filename);
+      showToast('Component zip downloaded!');
+    } catch (error) {
+      console.error('[CodeTools] Export failed', error);
+      showToast('Export failed ❌');
+    } finally {
+      if (button) {
+        button.disabled = false;
+        button.innerHTML = originalText || '<i class="fa-solid fa-file-zipper"></i> Export';
+      }
+    }
+  },
+
   /**
    * Initialize code tools feature
    */
@@ -133,6 +464,9 @@ const CodeTools = {
     window.copyCode = (id, btn) => this.copyCode(id, btn);
     window.copyColor = (color) => this.copyColor(color);
     window.copyRGB = (value) => this.copyRGB(value);
+    window.exportCode = (id, btn) => this.exportCode(id, btn);
+
+    this._injectExportButtons();
   }
 };
 


### PR DESCRIPTION
Added a Download as Zip export to the shared code-tools surface in js/features/code-tools.js. It now injects an Export button beside the existing code actions, lazily loads JSZip in the browser, resolves the active component’s HTML/CSS/optional JS, and downloads a zip containing `component.html`, `component.css`, optional `component.js`, and README.md.

I also added a local mapping/config file at data/meta/export-map.json so page-specific overrides and filename templates stay editable without touching the runtime logic. Validation is clean: `get_errors` passed for the edited files, and `git diff --check` found no formatting issues.


closes #1910