### PR TITLE
Component Download as ZIP

### DIFF
--- a/UI-Cards.html
+++ b/UI-Cards.html
@@ -550,6 +550,7 @@
 <script src="js/features/theme.js"></script>
 <script src="js/features/scroll.js"></script>
 <script src="js/features/alerts.js"></script>
+<script src="js/features/keyboard-shortcuts.js"></script>
 <script src="js/features/accessibility.js"></script>
 <script src="js/bootstrap.js"></script>
 <script src="js/features/cards-bind.js"></script>

--- a/UI-Cards.html
+++ b/UI-Cards.html
@@ -551,6 +551,7 @@
 <script src="js/features/scroll.js"></script>
 <script src="js/features/alerts.js"></script>
 <script src="js/features/keyboard-shortcuts.js"></script>
+<script src="js/features/download.js"></script>
 <script src="js/features/accessibility.js"></script>
 <script src="js/bootstrap.js"></script>
 <script src="js/features/cards-bind.js"></script>

--- a/cards.html
+++ b/cards.html
@@ -1868,6 +1868,7 @@
 <script src="js/features/sandbox.js"></script>
 <script src="js/features/device-preview.js"></script>
 <script src="js/features/keyboard-shortcuts.js"></script>
+<script src="js/features/download.js"></script>
 <script src="js/features/accessibility.js"></script>
 <script src="js/bootstrap.js"></script>
 <script src="script.js"></script>

--- a/cards.html
+++ b/cards.html
@@ -1867,6 +1867,7 @@
 <script src="js/features/alerts.js"></script>
 <script src="js/features/sandbox.js"></script>
 <script src="js/features/device-preview.js"></script>
+<script src="js/features/keyboard-shortcuts.js"></script>
 <script src="js/features/accessibility.js"></script>
 <script src="js/bootstrap.js"></script>
 <script src="script.js"></script>

--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -94,6 +94,10 @@ const Bootstrap = {
       UIverse.register('DevicePreview', DevicePreview);
     }
 
+    if (typeof KeyboardShortcuts !== 'undefined') {
+      UIverse.register('KeyboardShortcuts', KeyboardShortcuts);
+    }
+
     if (typeof TutorialMode !== 'undefined') {
       UIverse.register('TutorialMode', TutorialMode);
     }

--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -98,6 +98,10 @@ const Bootstrap = {
       UIverse.register('KeyboardShortcuts', KeyboardShortcuts);
     }
 
+    if (typeof Download !== 'undefined') {
+      UIverse.register('Download', Download);
+    }
+
     if (typeof TutorialMode !== 'undefined') {
       UIverse.register('TutorialMode', TutorialMode);
     }

--- a/js/features/download.js
+++ b/js/features/download.js
@@ -1,0 +1,408 @@
+/**
+ * Component Download Feature
+ * Downloads individual component packages (HTML + CSS + JS) as ZIP files.
+ */
+
+const Download = {
+  _state: {
+    initialized: false,
+    jsZipPromise: null
+  },
+
+  _storageKeys: {
+    counts: 'uiVerseDownloadCounts'
+  },
+
+  init() {
+    if (this._state.initialized) return;
+
+    this._injectStyles();
+    this._injectDownloadButtons();
+    this._state.initialized = true;
+  },
+
+  _injectStyles() {
+    if (document.getElementById('uiverse-download-style')) return;
+
+    const style = document.createElement('style');
+    style.id = 'uiverse-download-style';
+    style.textContent = `
+      .download-zip-btn .download-count-pill {
+        margin-left: 6px;
+        border: 1px solid rgba(255, 255, 255, 0.24);
+        border-radius: 999px;
+        padding: 1px 6px;
+        font-size: 10px;
+        line-height: 1;
+        opacity: 0.9;
+      }
+    `;
+    document.head.appendChild(style);
+  },
+
+  _normalizePath(value) {
+    return String(value || '').split('?')[0].split('#')[0];
+  },
+
+  _normalizeId(value) {
+    return String(value || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  },
+
+  _getPageSlug() {
+    const pathname = this._normalizePath(window.location.pathname || '');
+    const segment = pathname.split('/').filter(Boolean).pop() || 'index.html';
+    return segment.replace(/\.html?$/i, '').toLowerCase();
+  },
+
+  _loadScript(src) {
+    return new Promise((resolve, reject) => {
+      const existing = document.querySelector(`script[data-download-lib="${src}"]`);
+      if (existing) {
+        if (window.JSZip) {
+          resolve();
+        } else {
+          existing.addEventListener('load', () => resolve(), { once: true });
+          existing.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+        }
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = true;
+      script.dataset.downloadLib = src;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  },
+
+  _loadJSZip() {
+    if (window.JSZip) {
+      return Promise.resolve(window.JSZip);
+    }
+
+    if (!this._state.jsZipPromise) {
+      this._state.jsZipPromise = this._loadScript('https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js')
+        .then(() => window.JSZip)
+        .catch((error) => {
+          this._state.jsZipPromise = null;
+          throw error;
+        });
+    }
+
+    return this._state.jsZipPromise;
+  },
+
+  _readCounts() {
+    try {
+      const raw = localStorage.getItem(this._storageKeys.counts);
+      const parsed = raw ? JSON.parse(raw) : {};
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (error) {
+      return {};
+    }
+  },
+
+  _writeCounts(data) {
+    localStorage.setItem(this._storageKeys.counts, JSON.stringify(data || {}));
+  },
+
+  _incrementCount(componentId) {
+    const id = this._normalizeId(componentId);
+    if (!id) return 0;
+
+    const counts = this._readCounts();
+    counts[id] = Number(counts[id] || 0) + 1;
+    this._writeCounts(counts);
+    return counts[id];
+  },
+
+  _getCount(componentId) {
+    const id = this._normalizeId(componentId);
+    if (!id) return 0;
+
+    const counts = this._readCounts();
+    return Number(counts[id] || 0);
+  },
+
+  _extractCodeId(actions) {
+    const copyButton = actions.querySelector('button[onclick*="copyCode"]');
+    const toggleButton = actions.querySelector('button[onclick*="toggleCode"]');
+    const reference = copyButton || toggleButton;
+    const onclick = reference ? (reference.getAttribute('onclick') || '') : '';
+    const match = onclick.match(/['"]([^'"]+)['"]/);
+    return match ? match[1] : '';
+  },
+
+  _resolveCodeTextById(codeId) {
+    const element = document.getElementById(codeId);
+    if (!element) return '';
+
+    return (element.tagName === 'TEXTAREA' || element.tagName === 'INPUT')
+      ? element.value
+      : (element.innerText || element.textContent || '');
+  },
+
+  _resolveCodeTextFromCard(card) {
+    if (!card) return '';
+
+    const codeNode = card.querySelector('.code-block, pre code, pre, textarea');
+    if (!codeNode) return '';
+
+    if (codeNode.tagName === 'TEXTAREA' || codeNode.tagName === 'INPUT') {
+      return codeNode.value || '';
+    }
+
+    return codeNode.innerText || codeNode.textContent || '';
+  },
+
+  _extractHtmlCssJs(rawCode) {
+    const text = String(rawCode || '').trim();
+    if (!text) {
+      return { html: '', css: '', js: '' };
+    }
+
+    const cssMatch = text.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
+    const jsMatch = text.match(/<script[^>]*>([\s\S]*?)<\/script>/i);
+
+    let html = text
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+      .trim();
+
+    if (/<!doctype html>/i.test(text) || /<html[\s>]/i.test(text)) {
+      return {
+        html: text,
+        css: cssMatch ? cssMatch[1].trim() : '',
+        js: jsMatch ? jsMatch[1].trim() : ''
+      };
+    }
+
+    if (!/<[a-z][\s\S]*>/i.test(html)) {
+      html = `<div class="component-root">${html}</div>`;
+    }
+
+    return {
+      html,
+      css: cssMatch ? cssMatch[1].trim() : '',
+      js: jsMatch ? jsMatch[1].trim() : ''
+    };
+  },
+
+  _collectLocalStylesheets() {
+    const links = Array.from(document.querySelectorAll('link[rel="stylesheet"][href]'));
+    return links
+      .map((link) => this._normalizePath(link.getAttribute('href')))
+      .filter((href) => href && !/^https?:\/\//i.test(href) && !href.startsWith('data:'))
+      .filter((href) => !href.toLowerCase().includes('font-awesome'));
+  },
+
+  _collectLocalScripts() {
+    const scripts = Array.from(document.querySelectorAll('script[src]'));
+    return scripts
+      .map((script) => this._normalizePath(script.getAttribute('src')))
+      .filter((href) => href && !/^https?:\/\//i.test(href) && !href.startsWith('data:'))
+      .filter((href) => !href.toLowerCase().endsWith('bootstrap.js'))
+      .filter((href) => !href.toLowerCase().endsWith('script.js'));
+  },
+
+  async _fetchAssetText(assetPath) {
+    const resolved = new URL(assetPath, document.baseURI).href;
+    const response = await fetch(resolved, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`Failed to fetch ${assetPath}`);
+    return response.text();
+  },
+
+  _buildTemplateHtml(componentHtml) {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>UIverse Component Export</title>
+  <link rel="stylesheet" href="component.css">
+</head>
+<body>
+${componentHtml}
+<script src="component.js"></script>
+</body>
+</html>
+`;
+  },
+
+  _downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.rel = 'noopener';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1200);
+  },
+
+  _resolveComponentMeta(actions, fallbackCodeId) {
+    const card = actions?.closest?.('.component-card') || null;
+    const pageSlug = this._getPageSlug();
+    const label = card?.querySelector('.card-label, h3, h2, h4')?.textContent?.trim() || fallbackCodeId || 'component';
+
+    const componentId = this._normalizeId(`${pageSlug}-${label}`);
+    const filenameBase = this._normalizeId(label) || componentId || 'component';
+
+    return {
+      card,
+      componentId,
+      filenameBase,
+      label
+    };
+  },
+
+  _setButtonCount(button, componentId) {
+    const count = this._getCount(componentId);
+    if (count <= 0) return;
+
+    const pill = button.querySelector('.download-count-pill') || (() => {
+      const span = document.createElement('span');
+      span.className = 'download-count-pill';
+      button.appendChild(span);
+      return span;
+    })();
+
+    pill.textContent = String(count);
+  },
+
+  _createOrEnhanceButton(actions, codeId) {
+    let button = actions.querySelector('.download-zip-btn');
+    if (!button) {
+      const existingExport = actions.querySelector('.export-btn');
+      button = existingExport || document.createElement('button');
+
+      if (!existingExport) {
+        button.type = 'button';
+        button.className = 'action-btn download-zip-btn';
+        const copyButton = actions.querySelector('button[onclick*="copyCode"]');
+        if (copyButton && copyButton.nextSibling) {
+          actions.insertBefore(button, copyButton.nextSibling);
+        } else {
+          actions.appendChild(button);
+        }
+      }
+    }
+
+    button.classList.add('download-zip-btn');
+    button.removeAttribute('onclick');
+    button.setAttribute('aria-label', 'Download component as zip');
+    button.setAttribute('title', 'Download component as zip');
+    button.innerHTML = '<i class="fa-solid fa-file-zipper"></i> Download ZIP';
+
+    button.addEventListener('click', () => this.downloadByCodeId(codeId, button));
+    return button;
+  },
+
+  _injectDownloadButtons() {
+    document.querySelectorAll('.actions').forEach((actions) => {
+      if (actions.dataset.downloadButtonInjected === '1') return;
+
+      const codeId = this._extractCodeId(actions);
+      if (!codeId) return;
+
+      const meta = this._resolveComponentMeta(actions, codeId);
+      const button = this._createOrEnhanceButton(actions, codeId);
+      this._setButtonCount(button, meta.componentId);
+
+      actions.dataset.downloadButtonInjected = '1';
+    });
+  },
+
+  async _buildZipPayload(rawCode) {
+    const parsed = this._extractHtmlCssJs(rawCode);
+
+    const linkedStyles = this._collectLocalStylesheets();
+    const linkedScripts = this._collectLocalScripts();
+
+    const linkedCssChunks = await Promise.all(linkedStyles.map((stylePath) => this._fetchAssetText(stylePath).catch(() => '')));
+    const linkedJsChunks = await Promise.all(linkedScripts.map((scriptPath) => this._fetchAssetText(scriptPath).catch(() => '')));
+
+    const css = [...linkedCssChunks, parsed.css]
+      .filter((chunk) => String(chunk || '').trim())
+      .join('\n\n/* ---------------------------------------- */\n\n');
+
+    const js = [...linkedJsChunks, parsed.js]
+      .filter((chunk) => String(chunk || '').trim())
+      .join('\n\n// ----------------------------------------\n\n');
+
+    const html = /<!doctype html>/i.test(parsed.html) || /<html[\s>]/i.test(parsed.html)
+      ? parsed.html
+      : this._buildTemplateHtml(parsed.html || '<!-- No component markup detected -->');
+
+    return {
+      html,
+      css: css || '/* No page/component CSS detected for this export. */\n',
+      js: js || '// No page/component JS detected for this export.\n'
+    };
+  },
+
+  async downloadByCodeId(codeId, button) {
+    const actions = button?.closest?.('.actions') || null;
+    const meta = this._resolveComponentMeta(actions, codeId);
+    const rawCode = this._resolveCodeTextById(codeId) || this._resolveCodeTextFromCard(meta.card);
+
+    if (!rawCode || !rawCode.trim()) {
+      if (typeof showToast === 'function') showToast('No code found for this component');
+      return;
+    }
+
+    const originalText = button ? button.innerHTML : '';
+
+    try {
+      if (button) {
+        button.disabled = true;
+        button.innerHTML = 'Preparing ZIP...';
+      }
+
+      const JSZip = await this._loadJSZip();
+      const payload = await this._buildZipPayload(rawCode);
+
+      const zip = new JSZip();
+      zip.file('component.html', payload.html);
+      zip.file('component.css', payload.css);
+      zip.file('component.js', payload.js);
+      zip.file('README.md', `# ${meta.label}\n\nGenerated from UIverse (${this._getPageSlug()}).\n\nFiles:\n- component.html\n- component.css\n- component.js\n`);
+
+      const blob = await zip.generateAsync({ type: 'blob' });
+      this._downloadBlob(blob, `${meta.filenameBase || 'component'}-component.zip`);
+
+      this._incrementCount(meta.componentId);
+      this._setButtonCount(button, meta.componentId);
+
+      if (typeof showToast === 'function') showToast('Component ZIP downloaded');
+    } catch (error) {
+      console.error('[Download] ZIP export failed', error);
+      if (typeof showToast === 'function') showToast('Download failed ❌');
+    } finally {
+      if (button) {
+        button.disabled = false;
+        button.innerHTML = originalText || '<i class="fa-solid fa-file-zipper"></i> Download ZIP';
+        this._setButtonCount(button, meta.componentId);
+      }
+    }
+  },
+
+  destroy() {
+    this._state.initialized = false;
+  }
+};
+
+if (typeof window !== 'undefined') {
+  window.Download = Download;
+  window.downloadComponentZip = (codeId, button) => Download.downloadByCodeId(codeId, button);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = Download;
+}

--- a/js/features/keyboard-shortcuts.js
+++ b/js/features/keyboard-shortcuts.js
@@ -1,0 +1,412 @@
+/**
+ * Keyboard Shortcuts Feature
+ * Power-user keyboard navigation and discoverable shortcut hints.
+ */
+
+const KeyboardShortcuts = {
+  _state: {
+    initialized: false,
+    listeners: [],
+    helpModalOpen: false
+  },
+
+  _ids: {
+    helpOverlay: 'uiv-shortcuts-overlay',
+    helpModal: 'uiv-shortcuts-modal',
+    styles: 'uiv-shortcuts-style'
+  },
+
+  _shortcuts: [
+    { key: '/', description: 'Focus search input' },
+    { key: 'Ctrl+K / Cmd+K', description: 'Open command palette or focus search' },
+    { key: '?', description: 'Show keyboard shortcuts help' },
+    { key: 'Esc', description: 'Close open modals/overlays' }
+  ],
+
+  init() {
+    if (this._state.initialized) return;
+
+    this._injectStyles();
+    this._ensureHelpModal();
+    this._attachHints();
+    this._bindShortcuts();
+
+    this._state.initialized = true;
+  },
+
+  _injectStyles() {
+    if (document.getElementById(this._ids.styles)) return;
+
+    const style = document.createElement('style');
+    style.id = this._ids.styles;
+    style.textContent = `
+      .uiv-shortcut-hint-target {
+        position: relative;
+      }
+
+      .uiv-shortcut-hint-badge {
+        position: absolute;
+        top: -10px;
+        right: -8px;
+        font-size: 10px;
+        line-height: 1;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        border-radius: 999px;
+        padding: 4px 7px;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        color: #f2f5ff;
+        background: linear-gradient(135deg, rgba(235, 104, 53, 0.88), rgba(88, 103, 255, 0.85));
+        opacity: 0;
+        transform: translateY(-3px);
+        transition: opacity 0.15s ease, transform 0.15s ease;
+        pointer-events: none;
+        z-index: 15;
+      }
+
+      .uiv-shortcut-hint-target:hover .uiv-shortcut-hint-badge,
+      .uiv-shortcut-hint-target:focus-within .uiv-shortcut-hint-badge {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      #uiv-shortcuts-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 9998;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: rgba(6, 8, 14, 0.68);
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
+      }
+
+      #uiv-shortcuts-overlay.open {
+        display: flex;
+      }
+
+      #uiv-shortcuts-modal {
+        width: min(560px, 100%);
+        border-radius: 18px;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        background: linear-gradient(180deg, rgba(16, 20, 30, 0.98), rgba(10, 13, 20, 0.96));
+        color: #f4f6ff;
+        box-shadow: 0 22px 60px rgba(0, 0, 0, 0.45);
+        overflow: hidden;
+      }
+
+      .uiv-shortcuts-head {
+        padding: 16px 18px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .uiv-shortcuts-head h2 {
+        margin: 0;
+        font-size: 1.1rem;
+      }
+
+      .uiv-shortcuts-close {
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        background: transparent;
+        color: #f7f7f7;
+        border-radius: 10px;
+        width: 34px;
+        height: 34px;
+        cursor: pointer;
+      }
+
+      .uiv-shortcuts-list {
+        list-style: none;
+        margin: 0;
+        padding: 14px 18px 18px;
+        display: grid;
+        gap: 10px;
+      }
+
+      .uiv-shortcuts-item {
+        border: 1px solid rgba(255, 255, 255, 0.11);
+        border-radius: 12px;
+        padding: 11px 12px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+
+      .uiv-shortcuts-key {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .uiv-shortcuts-kbd {
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-bottom-width: 2px;
+        border-radius: 7px;
+        padding: 3px 8px;
+        font-size: 12px;
+        font-weight: 700;
+        color: #fff;
+        background: rgba(255, 255, 255, 0.08);
+      }
+
+      .uiv-shortcuts-desc {
+        color: #d0d7e7;
+        font-size: 0.93rem;
+      }
+
+      .uiv-shortcuts-kicker {
+        margin: 0;
+        padding: 0 18px 14px;
+        color: #9fa8bf;
+        font-size: 0.86rem;
+      }
+    `;
+
+    document.head.appendChild(style);
+  },
+
+  _ensureHelpModal() {
+    if (document.getElementById(this._ids.helpOverlay)) return;
+
+    const overlay = document.createElement('div');
+    overlay.id = this._ids.helpOverlay;
+    overlay.setAttribute('aria-hidden', 'true');
+
+    const itemsHtml = this._shortcuts.map((entry) => {
+      const keyParts = entry.key.split('/').map((part) => part.trim());
+      const keyHtml = keyParts
+        .map((part) => {
+          const chunks = part.split('+').map((chunk) => chunk.trim());
+          return `<span class="uiv-shortcuts-key">${chunks.map((chunk) => `<span class="uiv-shortcuts-kbd">${chunk}</span>`).join('')}</span>`;
+        })
+        .join('<span style="opacity:.6;">or</span>');
+
+      return `
+        <li class="uiv-shortcuts-item">
+          <div>${keyHtml}</div>
+          <span class="uiv-shortcuts-desc">${entry.description}</span>
+        </li>
+      `;
+    }).join('');
+
+    overlay.innerHTML = `
+      <div id="${this._ids.helpModal}" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts help">
+        <div class="uiv-shortcuts-head">
+          <h2>Keyboard Shortcuts</h2>
+          <button type="button" class="uiv-shortcuts-close" aria-label="Close shortcuts help">
+            <i class="fa-solid fa-xmark"></i>
+          </button>
+        </div>
+        <ul class="uiv-shortcuts-list">${itemsHtml}</ul>
+        <p class="uiv-shortcuts-kicker">Tip: press <strong>?</strong> anytime to reopen this help panel.</p>
+      </div>
+    `;
+
+    document.body.appendChild(overlay);
+
+    const onOverlayClick = (event) => {
+      if (event.target === overlay || event.target.closest('.uiv-shortcuts-close')) {
+        this.hideHelp();
+      }
+    };
+
+    overlay.addEventListener('click', onOverlayClick);
+    this._state.listeners.push({ el: overlay, event: 'click', handler: onOverlayClick });
+  },
+
+  _attachHint(target, hintText) {
+    if (!target || target.closest('.uiv-shortcut-hint-target')) return;
+
+    const wrapper = document.createElement('span');
+    wrapper.className = 'uiv-shortcut-hint-target';
+
+    target.parentNode?.insertBefore(wrapper, target);
+    wrapper.appendChild(target);
+
+    const badge = document.createElement('span');
+    badge.className = 'uiv-shortcut-hint-badge';
+    badge.textContent = hintText;
+    wrapper.appendChild(badge);
+  },
+
+  _attachHints() {
+    const searchInput = document.getElementById('searchInput');
+    if (searchInput) {
+      this._attachHint(searchInput, '/');
+      searchInput.setAttribute('title', 'Shortcut: /');
+    }
+
+    const commandPaletteTrigger = document.querySelector('#command-palette-trigger, [data-command-palette-trigger]');
+    if (commandPaletteTrigger) {
+      this._attachHint(commandPaletteTrigger, 'Ctrl+K');
+      commandPaletteTrigger.setAttribute('title', 'Shortcut: Ctrl+K');
+    }
+
+    const helpAnchor = document.querySelector('#uiv-shortcuts-help-trigger');
+    if (helpAnchor) {
+      this._attachHint(helpAnchor, '?');
+      helpAnchor.setAttribute('title', 'Shortcut: ?');
+    }
+  },
+
+  _isTypingContext(target) {
+    if (!target) return false;
+    if (target.isContentEditable) return true;
+    const tag = target.tagName ? target.tagName.toLowerCase() : '';
+    return tag === 'input' || tag === 'textarea' || tag === 'select';
+  },
+
+  _focusSearch() {
+    const searchInput = document.getElementById('searchInput');
+    if (!searchInput) return false;
+
+    searchInput.focus({ preventScroll: false });
+    if (typeof searchInput.select === 'function') {
+      searchInput.select();
+    }
+
+    return true;
+  },
+
+  _handleCtrlK() {
+    if (window.CommandPalette && typeof window.CommandPalette.toggle === 'function') {
+      window.CommandPalette.toggle();
+      return true;
+    }
+
+    return this._focusSearch();
+  },
+
+  _closeOpenUI() {
+    let closedSomething = false;
+
+    if (this._state.helpModalOpen) {
+      this.hideHelp();
+      closedSomething = true;
+    }
+
+    if (window.CommandPalette && typeof window.CommandPalette.close === 'function') {
+      const overlay = document.getElementById('commandPaletteOverlay');
+      if (overlay && overlay.classList.contains('open')) {
+        window.CommandPalette.close();
+        closedSomething = true;
+      }
+    }
+
+    if (window.closePopup && typeof window.closePopup === 'function') {
+      const popup = document.getElementById('popup');
+      if (popup && popup.classList.contains('open-popup')) {
+        window.closePopup();
+        closedSomething = true;
+      }
+    }
+
+    const closableSelectors = [
+      '.modal.open',
+      '.overlay.open',
+      '.popup.open',
+      '.playground-modal.open',
+      '.playground-backdrop.visible',
+      '[role="dialog"].open'
+    ];
+
+    closableSelectors.forEach((selector) => {
+      document.querySelectorAll(selector).forEach((node) => {
+        node.classList.remove('open');
+        node.classList.remove('visible');
+        node.classList.remove('active');
+        closedSomething = true;
+      });
+    });
+
+    return closedSomething;
+  },
+
+  showHelp() {
+    const overlay = document.getElementById(this._ids.helpOverlay);
+    if (!overlay) return;
+
+    overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden', 'false');
+    this._state.helpModalOpen = true;
+  },
+
+  hideHelp() {
+    const overlay = document.getElementById(this._ids.helpOverlay);
+    if (!overlay) return;
+
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
+    this._state.helpModalOpen = false;
+  },
+
+  _bindShortcuts() {
+    const onKeyDown = (event) => {
+      const key = event.key;
+      const target = event.target;
+
+      if ((event.ctrlKey || event.metaKey) && key.toLowerCase() === 'k') {
+        const commandPaletteReady =
+          Boolean(window.CommandPalette) &&
+          Boolean(document.getElementById('commandPaletteOverlay'));
+
+        if (commandPaletteReady) {
+          return;
+        }
+
+        event.preventDefault();
+        this._handleCtrlK();
+        return;
+      }
+
+      if (key === 'Escape') {
+        if (this._closeOpenUI()) {
+          event.preventDefault();
+        }
+        return;
+      }
+
+      if (!event.ctrlKey && !event.metaKey && !event.altKey && key === '/') {
+        if (!this._isTypingContext(target)) {
+          event.preventDefault();
+          this._focusSearch();
+        }
+        return;
+      }
+
+      if (!event.ctrlKey && !event.metaKey && !event.altKey && key === '?') {
+        if (!this._isTypingContext(target)) {
+          event.preventDefault();
+          this.showHelp();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    this._state.listeners.push({ el: document, event: 'keydown', handler: onKeyDown });
+  },
+
+  destroy() {
+    this._state.listeners.forEach(({ el, event, handler }) => {
+      el.removeEventListener(event, handler);
+    });
+    this._state.listeners = [];
+    this._state.helpModalOpen = false;
+    this._state.initialized = false;
+  }
+};
+
+if (typeof window !== 'undefined') {
+  window.KeyboardShortcuts = KeyboardShortcuts;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = KeyboardShortcuts;
+}

--- a/script.js
+++ b/script.js
@@ -339,6 +339,34 @@ function initKeyboardShortcutsFeature() {
   document.body.appendChild(script);
 }
 
+function initDownloadFeature() {
+  const hasCards = document.querySelector('.component-card');
+  const hasActions = document.querySelector('.actions');
+  if (!hasCards && !hasActions) return;
+
+  const start = () => {
+    if (window.Download && typeof window.Download.init === 'function') {
+      window.Download.init();
+    }
+  };
+
+  if (window.Download && typeof window.Download.init === 'function') {
+    start();
+    return;
+  }
+
+  const existingScript = document.querySelector('script[src$="js/features/download.js"]');
+  if (existingScript) {
+    existingScript.addEventListener('load', start, { once: true });
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.src = 'js/features/download.js';
+  script.onload = start;
+  document.body.appendChild(script);
+}
+
 function updateSidebarActiveLink() {
   const currentRoute = getNormalizedRoutePath();
 
@@ -653,6 +681,7 @@ window.addEventListener("DOMContentLoaded", () => {
   initLiveSandboxes();
   initDevicePreviewFeature();
   initKeyboardShortcutsFeature();
+  initDownloadFeature();
   initDarkMode();
   initScrollTop();
   initProgressBar();

--- a/script.js
+++ b/script.js
@@ -315,6 +315,30 @@ function initDevicePreviewFeature() {
   document.body.appendChild(script);
 }
 
+function initKeyboardShortcutsFeature() {
+  const start = () => {
+    if (window.KeyboardShortcuts && typeof window.KeyboardShortcuts.init === 'function') {
+      window.KeyboardShortcuts.init();
+    }
+  };
+
+  if (window.KeyboardShortcuts && typeof window.KeyboardShortcuts.init === 'function') {
+    start();
+    return;
+  }
+
+  const existingScript = document.querySelector('script[src$="js/features/keyboard-shortcuts.js"]');
+  if (existingScript) {
+    existingScript.addEventListener('load', start, { once: true });
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.src = 'js/features/keyboard-shortcuts.js';
+  script.onload = start;
+  document.body.appendChild(script);
+}
+
 function updateSidebarActiveLink() {
   const currentRoute = getNormalizedRoutePath();
 
@@ -628,6 +652,7 @@ window.addEventListener("DOMContentLoaded", () => {
   initLegacyCardFavorites();
   initLiveSandboxes();
   initDevicePreviewFeature();
+  initKeyboardShortcutsFeature();
   initDarkMode();
   initScrollTop();
   initProgressBar();

--- a/testimonials.html
+++ b/testimonials.html
@@ -725,6 +725,7 @@
 <script src="js/features/sandbox.js"></script>
 <script src="js/features/device-preview.js"></script>
 <script src="js/features/keyboard-shortcuts.js"></script>
+<script src="js/features/download.js"></script>
 <script src="js/features/accessibility.js"></script>
 <script src="js/bootstrap.js"></script>
 </body>

--- a/testimonials.html
+++ b/testimonials.html
@@ -724,6 +724,7 @@
 <script src="js/features/alerts.js"></script>
 <script src="js/features/sandbox.js"></script>
 <script src="js/features/device-preview.js"></script>
+<script src="js/features/keyboard-shortcuts.js"></script>
 <script src="js/features/accessibility.js"></script>
 <script src="js/bootstrap.js"></script>
 </body>


### PR DESCRIPTION
Implemented the component ZIP download feature.

What changed
1. Added download.js
- Injects “Download ZIP” buttons into component action bars.
- Loads JSZip from the CDN on demand.
- Builds a ZIP with:
1. `component.html`
2. `component.css`
3. `component.js`
4. README.md
- Bundles all local CSS and JS assets it can detect on the page, not just the first match.
- Tracks per-component download counts in localStorage under `uiVerseDownloadCounts`.

2. Wired the feature into bootstrap and legacy flows
- Registered in bootstrap.js.
- Loaded on bootstrap-based pages:
- cards.html
- testimonials.html
- UI-Cards.html
- Added lazy initialization in script.js for pages that use the legacy script path.

3. Download button placement
- The buttons are injected into existing `.actions` blocks beside the code controls, which is the current code-block action surface in this repo.

Validation
- No errors in download.js, bootstrap.js, or script.js.
- Existing HTML lint issues in cards.html, testimonials.html, and UI-Cards.html are pre-existing and unrelated to this feature.

closes #2084