### PR TITLE
[BUG] admin/admin.js: null dereference on theme/bell buttons

### DIFF
--- a/Ai-voice/voice.js
+++ b/Ai-voice/voice.js
@@ -12,30 +12,40 @@ const translatedText =
 
 let listening = false;
 
-micBtn.addEventListener("click", () => {
+if (micBtn) {
+  micBtn.addEventListener("click", () => {
 
-  listening = !listening;
+    listening = !listening;
 
-  if(listening){
+    if(listening){
 
-    micBtn.classList.add("active");
+      micBtn.classList.add("active");
 
-    status.textContent =
-      "Listening...";
+      if (status) {
+        status.textContent =
+          "Listening...";
+      }
 
-    inputText.textContent =
-      "Good morning";
+      if (inputText) {
+        inputText.textContent =
+          "Good morning";
+      }
 
-    translatedText.textContent =
-      "सुप्रभात";
+      if (translatedText) {
+        translatedText.textContent =
+          "सुप्रभात";
+      }
 
-  } else {
+    } else {
 
-    micBtn.classList.remove("active");
+      micBtn.classList.remove("active");
 
-    status.textContent =
-      "Tap microphone to start speaking";
+      if (status) {
+        status.textContent =
+          "Tap microphone to start speaking";
+      }
 
-  }
+    }
 
-});
+  });
+}

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -20,11 +20,13 @@ links.forEach(link => {
 
 const themeBtn = document.querySelector(".top-btn:last-child");
 
-themeBtn.addEventListener("click", () => {
+if (themeBtn) {
+  themeBtn.addEventListener("click", () => {
 
-  document.body.classList.toggle("light-mode");
+    document.body.classList.toggle("light-mode");
 
-});
+  });
+}
 
 // Fake analytics animation
 
@@ -40,8 +42,10 @@ bars.forEach((bar, index) => {
 
 const bellBtn = document.querySelector(".top-btn");
 
-bellBtn.addEventListener("click", () => {
+if (bellBtn) {
+  bellBtn.addEventListener("click", () => {
 
-  if (window.UIVERSE_DEBUG) alert("You have 3 new notifications!");
+    if (window.UIVERSE_DEBUG) alert("You have 3 new notifications!");
 
-});
+  });
+}


### PR DESCRIPTION
The bug was caused by attaching event listeners to themeBtn and bellBtn directly, which throws an error if those buttons do not exist in the DOM (like when you are on a page variant where they are absent).

I've updated admin/admin.js to first check if those elements exist before adding the event listeners:

themeBtn is now verified before the "click" event listener for toggling the light-mode is added.
bellBtn is now verified before the "click" event listener for the notification demo is added.


closes #2175