### PR TITLE
[BUG] admin-panel.js: clipboard API permission failure

### DIFF
--- a/admin-panel.js
+++ b/admin-panel.js
@@ -339,11 +339,34 @@ function copyCode(id) {
   if (!pre) return;
 
   const rawCode = pre.querySelector('code').textContent;
-  navigator.clipboard.writeText(rawCode).then(() => {
-    if (typeof showLiveToast === 'function') showLiveToast('Source code copied to clipboard!', 'success');
-  }).catch(() => {
-    if (typeof showLiveToast === 'function') showLiveToast('Copy failed, please retry.', 'error');
-  });
+  
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(rawCode).then(() => {
+      if (typeof showLiveToast === 'function') showLiveToast('Source code copied to clipboard!', 'success');
+    }).catch(() => {
+      if (typeof showLiveToast === 'function') showLiveToast('Copy failed, please retry.', 'error');
+    });
+  } else {
+    // Fallback for non-secure HTTP contexts
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = rawCode;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      const successful = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      
+      if (successful) {
+        if (typeof showLiveToast === 'function') showLiveToast('Source code copied to clipboard!', 'success');
+      } else {
+        if (typeof showLiveToast === 'function') showLiveToast('Copy failed, please retry.', 'error');
+      }
+    } catch (err) {
+      if (typeof showLiveToast === 'function') showLiveToast('Copy failed, please retry.', 'error');
+    }
+  }
 }
 
 // ==========================================


### PR DESCRIPTION
I have fixed the issue! The bug was occurring because navigator.clipboard is restricted to secure contexts (HTTPS). When developing or viewing the page locally over HTTP, the API is undefined, causing an immediate crash when the script attempts to call .writeText() before it even reaches the .catch().

I updated the copyCode function in admin-panel.js to implement a bulletproof fallback strategy:

The script first checks if navigator.clipboard.writeText actually exists.
If it does, it uses the modern Clipboard API as usual.
If it doesn't (like on non-secure HTTP pages), it automatically creates a hidden <textarea>, copies the code snippet using the legacy document.execCommand('copy') method, and then cleans up.
Now you can successfully copy code across both secure HTTPS production environments and insecure HTTP local testing!

closes #2181