### PR TITLE
[Feature: Tutorial Mode guided overlay + highlight

### DIFF
--- a/cards.html
+++ b/cards.html
@@ -1874,6 +1874,8 @@
 <script src="js/features/download.js"></script>
 <script src="js/features/accessibility.js"></script>
 <script src="js/features/a11y-checker.js"></script>
+<script src="js/features/tutorial-mode-steps.js"></script>
+<script src="js/features/tutorial-mode.js"></script>
 <script src="js/bootstrap.js"></script>
 <script src="js/features/compare.js"></script>
 <script src="script.js"></script>
@@ -1960,6 +1962,24 @@
       setTimeout(() => btn.closest('.notif-card').style.display = 'none', 300);
     });
   });
+</script>
+<script>
+  (function () {
+    const button = document.getElementById('startTutorialMode');
+    if (!button || !window.TutorialMode || !window.TutorialModeSteps) return;
+
+    const steps = window.TutorialModeSteps.cards || window.TutorialModeSteps.default;
+    if (!Array.isArray(steps) || steps.length === 0) return;
+
+    button.addEventListener('click', () => {
+      window.TutorialMode.start({
+        pageKey: 'cards',
+        categoryKey: 'cards',
+        steps,
+        force: true
+      });
+    });
+  })();
 </script>
 <script src="playground.js"></script>
 </body>

--- a/js/features/tutorial-mode.js
+++ b/js/features/tutorial-mode.js
@@ -14,7 +14,8 @@ const TutorialMode = {
     overlayEl: null,
     tooltipEl: null,
     highlightEl: null,
-    completionKey: ''
+    completionKey: '',
+    lastOptions: null
   },
 
   _storageKeys: {
@@ -43,15 +44,16 @@ const TutorialMode = {
 
   /**
    * Start tutorial for a given page/category.
-   * @param {{pageKey?: string, categoryKey?: string, steps: Array}} options
+   * @param {{pageKey?: string, categoryKey?: string, steps: Array, force?: boolean}} options
    */
-  start({ pageKey, categoryKey, steps }) {
+  start({ pageKey, categoryKey, steps, force = false } = {}) {
     this._state.pageKey = pageKey || 'global';
     this._state.categoryKey = categoryKey || 'general';
     this._state.completionKey = this._buildCompletionKey(this._state.pageKey, this._state.categoryKey);
+    this._state.lastOptions = { pageKey: this._state.pageKey, categoryKey: this._state.categoryKey, steps };
 
     if (!steps || !Array.isArray(steps) || steps.length === 0) return;
-    if (this._isCompleted()) return;
+    if (!force && this._isCompleted()) return;
 
     this._state.steps = steps;
     this._state.currentIndex = 0;
@@ -65,11 +67,23 @@ const TutorialMode = {
   },
 
   restart() {
+    const lastOptions = this._state.lastOptions || {};
     try {
       localStorage.removeItem(this._state.completionKey);
     } catch {}
     this._state.currentIndex = 0;
     this._state.active = true;
+
+    if (this._state.steps.length === 0 && Array.isArray(lastOptions.steps) && lastOptions.steps.length > 0) {
+      this.start({
+        pageKey: lastOptions.pageKey,
+        categoryKey: lastOptions.categoryKey,
+        steps: lastOptions.steps,
+        force: true
+      });
+      return;
+    }
+
     this._render();
   },
 
@@ -80,7 +94,18 @@ const TutorialMode = {
     const link = document.createElement('link');
     link.id = 'tutorial-mode-css';
     link.rel = 'stylesheet';
-    link.href = 'tutorial-mode.css';
+    const scriptSource = (() => {
+      if (document.currentScript && document.currentScript.src) {
+        return document.currentScript.src;
+      }
+
+      const scriptEl = document.querySelector('script[src*="js/features/tutorial-mode.js"]');
+      return scriptEl ? scriptEl.src : '';
+    })();
+
+    link.href = scriptSource
+      ? new URL('../../tutorial-mode.css', scriptSource).href
+      : 'tutorial-mode.css';
     document.head.appendChild(link);
   },
 


### PR DESCRIPTION
Tutorial Mode is wired up on the cards page now. js/features/tutorial-mode.js now resolves tutorial-mode.css relative to the feature script, keeps the last page/category config, and supports reopening a completed tour from the page button. cards.html now loads tutorial-mode-steps.js and tutorial-mode.js and binds Start tutorial to the cards step set.

I validated js/features/tutorial-mode.js with the editor error check; no errors were found. If you want, I can wire the same tutorial start button into the other category pages next.


closes #2383