### PR TITLE
fix: improve readability and contrast in contact form inputs

### DIFF
--- a/contact.css
+++ b/contact.css
@@ -237,7 +237,7 @@
   position: absolute;
   left: 14px;
   font-size: 14px;
-  color: var(--text-muted);
+  color: rgba(255, 255, 255, 0.7);
   pointer-events: none;
   z-index: 1;
   transition: color var(--transition);
@@ -248,10 +248,10 @@
 .field-wrap textarea {
   width: 100%;
   padding: 12px 16px 12px 42px;
-  border: 1.5px solid rgba(255, 255, 255, 0.08);
+  border: 1.5px solid rgba(255, 255, 255, 0.12);
   border-radius: var(--radius-sm);
-  background: rgba(10, 10, 15, 0.6);
-  color: var(--text-primary);
+  background: rgba(10, 10, 15, 0.75);
+  color: #ffffff;
   font-family: var(--font-body);
   font-size: 14px;
   outline: none;
@@ -268,7 +268,8 @@
 
 .field-wrap input::placeholder,
 .field-wrap textarea::placeholder {
-  color: var(--text-muted);
+  color: rgba(255, 255, 255, 0.65);
+  opacity: 1;
 }
 
 /* Input Focus Glows */


### PR DESCRIPTION
## Related Issue
Closes #2285 

## Summary
Improved the readability and accessibility of the Contact Form inputs in the “Send a Message” section by increasing text and placeholder contrast against the dark background.

## Changes Made
- Updated input, select, and textarea text color for better visibility
- Improved placeholder text contrast and opacity
- Enhanced border and background contrast for clearer form fields
- Improved icon visibility inside form inputs

## Testing
Verified the changes locally by:
- Running the project in the browser
- Checking visibility of all form fields and placeholders
- Testing focus states and dropdown readability
- Confirming responsiveness and consistent appearance across the form

## Screenshots

# Before
<img width="1916" height="908" alt="Screenshot 2026-05-20 152040" src="https://github.com/user-attachments/assets/e431a879-cfd8-4c9d-a913-eb5be80ca7b8" />

# After
<img width="1866" height="919" alt="Screenshot 2026-05-21 152324" src="https://github.com/user-attachments/assets/ba1619f5-c692-4f01-856f-f3caddc3a881" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [ ] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)

Thank you reviewing my PR!