### PR TITLE
Add site search to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="home.css">
+  <link rel="stylesheet" href="command-palette.css">
 </head>
 
 <body>
@@ -97,8 +98,12 @@
 
   <div class="search-bar">
     <i class="fa-solid fa-magnifying-glass search-icon"></i>
-    <input type="text" id="searchInput" placeholder="Search components..." onkeydown="handleSearch(event)" />
+    <input type="text" id="searchInput" placeholder="Search components..." aria-label="Search components" />
     <kbd class="search-kbd">⌘K</kbd>
+  </div>
+
+  <div id="searchDropdown" class="search-dropdown hidden">
+    <ul id="searchDropdownResults" class="search-dropdown-results"></ul>
   </div>
 
   <div class="nav-right">
@@ -502,19 +507,29 @@
   </div>
 </footer>
 
+<script src="js/core/utils.js"></script>
+<script src="js/core/component-discovery.js"></script>
+<script src="js/core/component-index.js"></script>
+<script src="js/features/search.js"></script>
 <script src="script.js"></script>
 <script>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.Search && typeof Search.init === 'function') {
+      Search.init();
+    }
+  });
+
   // Dark mode toggle
-  const toggle = document.getElementById('darkModeToggle');
-  const icon = toggle.querySelector('i');
+  const darkModeToggleBtn = document.getElementById('darkModeToggle');
+  const darkModeIcon = darkModeToggleBtn.querySelector('i');
   if (localStorage.getItem('theme') === 'dark') {
     document.body.classList.add('dark-mode');
-    icon.className = 'fa-solid fa-sun';
+    darkModeIcon.className = 'fa-solid fa-sun';
   }
-  toggle.addEventListener('click', () => {
+  darkModeToggleBtn.addEventListener('click', () => {
     document.body.classList.toggle('dark-mode');
     const isDark = document.body.classList.contains('dark-mode');
-    icon.className = isDark ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
+    darkModeIcon.className = isDark ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
   });
 
@@ -544,7 +559,7 @@
   });
 
   // Animate elements on scroll
-  const observer = new IntersectionObserver((entries) => {
+  const homeObserver = new IntersectionObserver((entries) => {
     entries.forEach(e => {
       if (e.isIntersecting) {
         e.target.classList.add('in-view');
@@ -553,15 +568,8 @@
   }, { threshold: 0.1 });
 
   document.querySelectorAll('.feature-card, .cat-card, .why-card').forEach(el => {
-    observer.observe(el);
+    homeObserver.observe(el);
   });
-
-  function handleSearch(e) {
-    if (e.key === 'Enter') {
-      const q = document.getElementById('searchInput').value.trim();
-      if (q) alert('Searching for: ' + q);
-    }
-  }
 
   function subscribe() {
     const input = document.querySelector('.newsletter-form input');

--- a/js/features/search.js
+++ b/js/features/search.js
@@ -287,3 +287,5 @@ const Search = {
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = Search;
 }
+
+window.Search = Search;


### PR DESCRIPTION
Closes: #2398 
Author: @goyaljiiiiii

Adds a working site-wide search to the home page using the shared discovery/search system.

Changes Made
Added the search dropdown UI to index.html.
Loaded the shared discovery/search scripts needed for results.
Connected the home search input to the existing Search module.
Fixed script name collisions so the page loads without syntax errors.
Testing
Verified locally in the browser that the home page loads, the search initializes, and typing a query like "button" shows matching dropdown results.

Screenshots
Not included.

Checklist

1.  Code follows project style
2.  Tested locally
3.  No unrelated changes included
4.  If component behavior/UI changed, metadata version and changelog were updated (npm run components:version:check)