### PR TITLE
[Bug]: Compare overlay uses e.target === overlay click-to-close

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -222,18 +222,15 @@
       document.body.appendChild(overlay);
 
       overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) closeOverlayKeepSelection();
+        if (e.target instanceof Element && !e.target.closest('.uiverse-compare-overlay__panel')) {
+          closeOverlayKeepSelection();
+        }
       });
 
       const clearBtn = document.getElementById('uiverse-compare-clear');
       const closeBtn = document.getElementById('uiverse-compare-close');
 
-      clearBtn.addEventListener('click', () => {
-        state.selectedIds = [];
-        persistSelection();
-        refreshCheckboxStates();
-        closeOverlayClearSelection();
-      });
+      clearBtn.addEventListener('click', () => closeOverlayClearSelection());
 
       closeBtn.addEventListener('click', () => closeOverlayKeepSelection());
 
@@ -268,24 +265,24 @@
   function closeOverlayKeepSelection() {
     const overlay = document.getElementById(OVERLAY_ID);
     if (!overlay) return;
+    syncActive(null);
     overlay.classList.remove('uiverse-compare-overlay--open');
     state.overlayOpen = false;
   }
 
   function closeOverlayClearSelection() {
-    const overlay = document.getElementById(OVERLAY_ID);
-    if (!overlay) return;
-    overlay.classList.remove('uiverse-compare-overlay--open');
-    state.overlayOpen = false;
+    state.selectedIds = [];
+    persistSelection();
+    refreshCheckboxStates();
+    closeOverlayKeepSelection();
   }
 
   function onKeyDown(e) {
-    if (e.key !== 'Escape') return;
+    if (e.key !== 'Escape' || !state.overlayOpen) return;
 
-    // Requirement: Escape exits compare mode.
-    // Close overlay but keep selections; also clear active synchronized state.
-    syncActive(null);
-    closeOverlayKeepSelection();
+    // Escape exits compare mode completely.
+    e.preventDefault();
+    closeOverlayClearSelection();
   }
 
   function maybeInit() {


### PR DESCRIPTION
Implemented the fix in compare.js.

What changed:
1. Escape now exits compare mode completely.
2. Esc now clears selected compare IDs, persists empty state, refreshes checkboxes, and closes the overlay.
3. Backdrop click-close logic is now more robust:
   - Replaced strict target equality check with a panel-containment check, so any click outside the overlay panel closes reliably.
4. Clear button now uses the same clear-and-close path to keep behavior consistent.
5. Closing the overlay now also resets active sync highlight state.

Validation:
- Checked diagnostics for compare.js: no errors found.

closes #2388