### PR TITLE
Compare selection persistence

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -289,7 +289,12 @@
     const cards = getCardElements();
     if (!cards.length) return;
 
-    state.selectedIds = loadSelection();
+    const restoredIds = loadSelection();
+
+    // Keep only IDs that are present on this page load.
+    const validIds = new Set(cards.map((card) => ensureCompareId(card)).filter(Boolean));
+    state.selectedIds = restoredIds.filter((id) => validIds.has(id)).slice(0, MAX_COMPARE);
+    persistSelection();
 
     // Inject checkboxes once
     cards.forEach((card) => {


### PR DESCRIPTION
Added and tightened compare selection persistence behavior in compare.js.

What I changed:
1. On init, restored IDs are now validated against current page cards.
2. Invalid/stale IDs are dropped.
3. Cleaned selection is persisted back to sessionStorage.
4. Overlay reopen logic still triggers when there are at least 2 valid restored selections.

Key effect:
- Refreshing in the same tab/session reliably restores valid checked cards and reopens compare overlay when possible.
- Prevents stale IDs from previous page states from causing inconsistent selection counts.

Diagnostics:
- No errors in compare.js.

closes #2389