### PR TITLE
Checkbox injection may misbehave with DOM re-renderin

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -13,6 +13,9 @@
     overlayOpen: false,
   };
 
+  let cardsObserver = null;
+  let reconcileQueued = false;
+
   function getCardElements() {
     return Array.from(document.querySelectorAll(CARD_SELECTOR));
   }
@@ -31,7 +34,9 @@
 
     const raw = name ? `${name}__${cat}` : `card__${idx}`;
     const safe = raw.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
-    const id = `${safe}__${idx}`;
+
+    // Keep metadata-backed IDs stable across DOM re-renders.
+    const id = name ? safe : `${safe}__${idx}`;
 
     cardEl.setAttribute(CARD_ID_ATTR, id);
     return id;
@@ -310,6 +315,45 @@
     }
   }
 
+  function mutationTouchesCards(mutations) {
+    const hasCard = (node) => {
+      if (!(node instanceof Element)) return false;
+      return node.matches(CARD_SELECTOR) || !!node.querySelector(CARD_SELECTOR);
+    };
+
+    return mutations.some((mutation) => {
+      if (mutation.type !== 'childList') return false;
+      return Array.from(mutation.addedNodes).some(hasCard) || Array.from(mutation.removedNodes).some(hasCard);
+    });
+  }
+
+  function scheduleCardReconcile() {
+    if (reconcileQueued) return;
+    reconcileQueued = true;
+
+    const run = () => {
+      reconcileQueued = false;
+      maybeInit();
+    };
+
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(run);
+      return;
+    }
+    setTimeout(run, 0);
+  }
+
+  function observeDynamicCards() {
+    if (cardsObserver || typeof MutationObserver === 'undefined' || !document.body) return;
+
+    cardsObserver = new MutationObserver((mutations) => {
+      if (!mutationTouchesCards(mutations)) return;
+      scheduleCardReconcile();
+    });
+
+    cardsObserver.observe(document.body, { childList: true, subtree: true });
+  }
+
   // Styles injected only when needed (so compare doesn't affect other pages too much)
   function injectStylesOnce() {
     if (document.getElementById('uiverse-compare-styles')) return;
@@ -452,10 +496,12 @@
     document.addEventListener('DOMContentLoaded', () => {
       injectStylesOnce();
       maybeInit();
+      observeDynamicCards();
     });
   } else {
     injectStylesOnce();
     maybeInit();
+    observeDynamicCards();
   }
 })();
 

--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -289,7 +289,12 @@
     const cards = getCardElements();
     if (!cards.length) return;
 
-    state.selectedIds = loadSelection();
+    const restoredIds = loadSelection();
+
+    // Keep only IDs that are present on this page load.
+    const validIds = new Set(cards.map((card) => ensureCompareId(card)).filter(Boolean));
+    state.selectedIds = restoredIds.filter((id) => validIds.has(id)).slice(0, MAX_COMPARE);
+    persistSelection();
 
     // Inject checkboxes once
     cards.forEach((card) => {


### PR DESCRIPTION
Implemented a fix for dynamic re-render consistency in compare.js.

What was added:
1. DOM re-render reconciliation:
- Added a MutationObserver that watches for added/removed card nodes.
- When card DOM changes are detected, compare state is re-initialized on the next frame.
- This re-injects missing checkboxes for new card nodes and re-syncs checked/disabled states from persisted selection.

2. More stable ID generation for metadata-backed cards:
- In compare.js, cards with data-name/data-cat now get a stable compare ID that does not depend on index.
- Index-based fallback is still used when metadata is missing.

Why this fixes the bug:
- In React/Vue-like replacement, old card elements disappear and new ones lose injected controls.
- The observer now catches those replacements and reapplies compare wiring automatically.
- Stable IDs reduce selection mismatch after re-render when card ordering changes.

Validation:
- Diagnostics run on compare.js: no errors found.

closes #2390