### PR TITLE
feat(loaders): add 4 new animated loader components

### DIFF
--- a/loaders.css
+++ b/loaders.css
@@ -1097,6 +1097,153 @@ body.dark-mode .skeleton-card{
 
 }
 
+/* ===============================
+   SPINNING GEARS LOADER (#18)
+================================= */
+
+.icon-spin-loader {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-spin-loader i:first-child {
+  font-size: 42px;
+  color: #7c5cff;
+  animation: spin 2s linear infinite;
+  filter: drop-shadow(0 0 8px rgba(124,92,255,0.5));
+}
+
+.icon-spin-loader i:last-child {
+  font-size: 20px;
+  color: #fd79a8;
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  animation: spin 1.2s linear infinite reverse;
+  filter: drop-shadow(0 0 5px rgba(253,121,168,0.5));
+}
+
+/* ===============================
+   ICON PULSE RING (#19)
+================================= */
+
+.icon-pulse-ring {
+  position: relative;
+  width: 70px;
+  height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-pulse-ring i {
+  font-size: 26px;
+  color: #ffd32a;
+  z-index: 2;
+  filter: drop-shadow(0 0 6px rgba(255,211,42,0.7));
+  animation: icon-pulse-icon 1.4s ease-in-out infinite;
+}
+
+.icon-pulse-ring span {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 3px solid rgba(255,211,42,0.6);
+  animation: icon-pulse-ring-anim 1.4s ease-out infinite;
+}
+
+.icon-pulse-ring span:nth-child(3) {
+  animation-delay: 0.55s;
+  border-color: rgba(124,92,255,0.45);
+}
+
+@keyframes icon-pulse-ring-anim {
+  0%   { transform: scale(0.6); opacity: 1; }
+  100% { transform: scale(1.9); opacity: 0; }
+}
+
+@keyframes icon-pulse-icon {
+  0%, 100% { transform: scale(1); }
+  50%       { transform: scale(1.18); }
+}
+
+/* ===============================
+   CIRCULAR TEXT ORBIT (#20)
+================================= */
+
+.text-orbit-loader {
+  position: relative;
+  width: 110px;
+  height: 110px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.text-orbit-loader svg {
+  position: absolute;
+  top: 0; left: 0;
+  animation: spin 7s linear infinite;
+}
+
+.text-orbit-icon {
+  font-size: 26px;
+  color: #7c5cff;
+  z-index: 2;
+  animation: spin 2s linear infinite;
+  filter: drop-shadow(0 0 7px rgba(124,92,255,0.55));
+}
+
+/* ===============================
+   STACKED SQUARES (#21)
+================================= */
+
+.stacked-squares {
+  position: relative;
+  width: 54px;
+  height: 54px;
+}
+
+.stacked-squares span {
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+  border: 3px solid transparent;
+  animation: stack-spin 2.4s cubic-bezier(.4,0,.2,1) infinite;
+}
+
+.stacked-squares span:nth-child(1) {
+  border-color: #7c5cff;
+  animation-delay: 0s;
+  box-shadow: inset 0 0 0 1.5px rgba(124,92,255,0.12);
+}
+
+.stacked-squares span:nth-child(2) {
+  inset: 9px;
+  border-color: #fd79a8;
+  animation-delay: -0.8s;
+  border-radius: 7px;
+}
+
+.stacked-squares span:nth-child(3) {
+  inset: 18px;
+  border-color: #00f7ff;
+  animation-delay: -1.6s;
+  border-radius: 4px;
+}
+
+@keyframes stack-spin {
+  0%   { transform: rotate(0deg) scale(1); }
+  25%  { transform: rotate(90deg) scale(1.08); }
+  50%  { transform: rotate(180deg) scale(1); }
+  75%  { transform: rotate(270deg) scale(0.92); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+
 /* ============================================================
    FOOTER
    ============================================================ */

--- a/loaders.html
+++ b/loaders.html
@@ -1520,6 +1520,108 @@
         </pre>
       </div>
 
+      <!-- Loader 18 — Spinning Gear -->
+      <div class="component-card">
+        <h3>Spinning Gear Loader</h3>
+        <div class="loader-demo-box">
+          <div class="icon-spin-loader">
+            <i class="fa-solid fa-gear"></i>
+            <i class="fa-solid fa-gear"></i>
+          </div>
+        </div>
+        <div class="actions">
+          <button onclick="toggleCode('loader18')">View Code</button>
+          <button onclick="copyCode('loader18')">Copy</button>
+        </div>
+        <pre id="loader18" class="code-block">
+      &lt;div class="icon-spin-loader"&gt;
+        &lt;i class="fa-solid fa-gear"&gt;&lt;/i&gt;
+        &lt;i class="fa-solid fa-gear"&gt;&lt;/i&gt;
+      &lt;/div&gt;
+        </pre>
+      </div>
+
+      <!-- Loader 19 — Icon Pulse Ring -->
+      <div class="component-card">
+        <h3>Icon Pulse Ring</h3>
+        <div class="loader-demo-box">
+          <div class="icon-pulse-ring">
+            <i class="fa-solid fa-bolt"></i>
+            <span></span>
+            <span></span>
+          </div>
+        </div>
+        <div class="actions">
+          <button onclick="toggleCode('loader19')">View Code</button>
+          <button onclick="copyCode('loader19')">Copy</button>
+        </div>
+        <pre id="loader19" class="code-block">
+      &lt;div class="icon-pulse-ring"&gt;
+        &lt;i class="fa-solid fa-bolt"&gt;&lt;/i&gt;
+        &lt;span&gt;&lt;/span&gt;
+        &lt;span&gt;&lt;/span&gt;
+      &lt;/div&gt;
+        </pre>
+      </div>
+
+      <!-- Loader 20 — Circular Text Orbit -->
+      <div class="component-card">
+        <h3>Circular Text Orbit</h3>
+        <div class="loader-demo-box">
+          <div class="text-orbit-loader">
+            <svg viewBox="0 0 100 100" width="110" height="110">
+              <path id="orbit-path" d="M 50,50 m -32,0 a 32,32 0 1,1 64,0 a 32,32 0 1,1 -64,0" fill="none"/>
+              <text font-size="10.5" fill="#7c5cff" font-family="DM Sans, sans-serif" font-weight="700" letter-spacing="3">
+                <textPath href="#orbit-path">LOADING • PLEASE WAIT •</textPath>
+              </text>
+            </svg>
+            <i class="fa-solid fa-circle-notch text-orbit-icon"></i>
+          </div>
+        </div>
+        <div class="actions">
+          <button onclick="toggleCode('loader20')">View Code</button>
+          <button onclick="copyCode('loader20')">Copy</button>
+        </div>
+        <pre id="loader20" class="code-block">
+      &lt;div class="text-orbit-loader"&gt;
+        &lt;svg viewBox="0 0 100 100" width="110" height="110"&gt;
+          &lt;path id="orbit-path"
+            d="M 50,50 m -32,0 a 32,32 0 1,1 64,0 a 32,32 0 1,1 -64,0"
+            fill="none"/&gt;
+          &lt;text font-size="10.5" fill="#7c5cff"
+            font-family="DM Sans, sans-serif"
+            font-weight="700" letter-spacing="3"&gt;
+            &lt;textPath href="#orbit-path"&gt;LOADING • PLEASE WAIT •&lt;/textPath&gt;
+          &lt;/text&gt;
+        &lt;/svg&gt;
+        &lt;i class="fa-solid fa-circle-notch text-orbit-icon"&gt;&lt;/i&gt;
+      &lt;/div&gt;
+        </pre>
+      </div>
+
+      <!-- Loader 21 — Stacked Squares -->
+      <div class="component-card">
+        <h3>Stacked Squares</h3>
+        <div class="loader-demo-box">
+          <div class="stacked-squares">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        </div>
+        <div class="actions">
+          <button onclick="toggleCode('loader21')">View Code</button>
+          <button onclick="copyCode('loader21')">Copy</button>
+        </div>
+        <pre id="loader21" class="code-block">
+      &lt;div class="stacked-squares"&gt;
+        &lt;span&gt;&lt;/span&gt;
+        &lt;span&gt;&lt;/span&gt;
+        &lt;span&gt;&lt;/span&gt;
+      &lt;/div&gt;
+        </pre>
+      </div>
+
     </div>
 
 


### PR DESCRIPTION
## Related Issue
Closes #2424 

## Summary
Adds 4 new animated loader components to the Loaders page, including two that incorporate Font Awesome icons.

## Changes Made
- Added **Spinning Gears Loader** — two FA gear icons counter-rotating at different speeds with a purple/pink glow effect
- Added **Icon Pulse Ring Loader** — a FA bolt icon centered inside two expanding ripple rings with offset timing and colors
- Added **Circular Text Orbit Loader** — SVG `textPath`-based "LOADING • PLEASE WAIT •" text orbiting a spinning FA circle-notch icon
- Added **Stacked Squares Loader** — three concentric squares rotating with staggered delays, each in a different accent color

## Testing
Opened `loaders.html` locally in the browser and verified all 4 loaders animate correctly. Tested "View Code" toggle and "Copy" button for each card. Checked light and dark mode. Confirmed no layout breakage on mobile viewport.

## Screenshots
<img width="1896" height="1078" alt="image" src="https://github.com/user-attachments/assets/68657fda-d615-4e97-aac4-428713c5d2dd" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [ ] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)