### PR TITLE
feat: add scroll-to-top button on dropdown page

### DIFF
--- a/dropdown-components.css
+++ b/dropdown-components.css
@@ -1227,6 +1227,27 @@ body{
   opacity: 1;
 }
 
+#scrollTopBtn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #FFA500; /* light orange */
+  color: white;
+  border: none;
+  border-radius: 50%;
+  padding: 12px;
+  font-size: 18px;
+  cursor: pointer;
+  display: none; /* hidden by default */
+  box-shadow: 0 4px 6px rgba(0,0,0,0.2);
+  transition: background 0.3s ease;
+  z-index: 1000;
+}
+
+#scrollTopBtn:hover {
+  background: #FFB84D; /* softer orange on hover */
+}
+
 
 
 

--- a/dropdown-components.html
+++ b/dropdown-components.html
@@ -1658,8 +1658,13 @@ MAIN
   Copied to clipboard!
 </div>
 
-<button id="scrollTopBtn" onclick="scrollToTop()">
-  <i class="fa-solid fa-chevron-up"></i>
+<button
+  id="scrollTopBtn"
+  type="button"
+  aria-label="Scroll to top"
+  title="Scroll to top"
+>
+  <i class="fa-solid fa-chevron-up" aria-hidden="true"></i>
 </button>
 
 

--- a/dropdown-components.html
+++ b/dropdown-components.html
@@ -1658,6 +1658,11 @@ MAIN
   Copied to clipboard!
 </div>
 
+<button id="scrollTopBtn" onclick="scrollToTop()">
+  <i class="fa-solid fa-chevron-up"></i>
+</button>
+
+
 <script src="dropdown.js"></script>
 
 </body>

--- a/dropdown.js
+++ b/dropdown.js
@@ -100,16 +100,22 @@ document.addEventListener('DOMContentLoaded', () => {
       wrapper.classList.remove('active');
     });
   });
-  
+
   const scrollBtn = document.getElementById("scrollTopBtn");
 
+  if (scrollBtn) {
+  scrollBtn.addEventListener("click", scrollToTop);
+}
+
   window.addEventListener("scroll", () => {
-    if (window.scrollY > 300) {
-      scrollBtn.style.display = "block";
-    } else {
-      scrollBtn.style.display = "none";
-    }
-  });
+  if (!scrollBtn) return;
+
+  if (window.scrollY > 300) {
+    scrollBtn.style.display = "block";
+  } else {
+    scrollBtn.style.display = "none";
+  }
+});
 });
 
 // ✅ Global scroll-to-top function (outside DOMContentLoaded)

--- a/dropdown.js
+++ b/dropdown.js
@@ -100,7 +100,25 @@ document.addEventListener('DOMContentLoaded', () => {
       wrapper.classList.remove('active');
     });
   });
+  
+  const scrollBtn = document.getElementById("scrollTopBtn");
+
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 300) {
+      scrollBtn.style.display = "block";
+    } else {
+      scrollBtn.style.display = "none";
+    }
+  });
 });
+
+// ✅ Global scroll-to-top function (outside DOMContentLoaded)
+function scrollToTop() {
+  window.scrollTo({
+    top: 0,
+    behavior: "smooth"
+  });
+}
 
 // Expand/Collapse Code Block
 let toastTimer;


### PR DESCRIPTION
## Related Issue
Closes #2406 

## Summary
This pull request implements a **scroll-to-top button** on the dropdown page.  
The button appears after scrolling down a certain distance and allows users to smoothly return to the top of the page, improving usability and accessibility.

## Changes Made
- Added a new `<button id="scrollTopBtn">` element with a Font Awesome chevron-up icon.
- Implemented JavaScript logic to show/hide the button after scrolling 300px.
- Defined a global `scrollToTop()` function for smooth scrolling behavior.
- Styled the button with a light orange theme and hover effect for better UI consistency.

## Testing
- Verified locally by opening `dropdown-components.html`.
- Scrolled down the page → button appears after 300px.
- Clicked the button → page smoothly scrolls back to the top.
- Tested in both light and dark themes to ensure consistent visibility.

## Screenshots
**Before:**  
<img width="1845" height="907" alt="Screenshot 2026-05-21 160319" src="https://github.com/user-attachments/assets/7dbebb8e-1db8-4fe4-948b-546da7da409a" />

**After:**  
<img width="1690" height="904" alt="Screenshot 2026-05-22 165213" src="https://github.com/user-attachments/assets/2e8e054f-8fa5-477f-b06b-d20d7478d6f8" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)
