### PR TITLE
feat(error page): add filter & sort toolbar to error page components …

### DIFF
--- a/error.css
+++ b/error.css
@@ -124,6 +124,171 @@ body{
 }
 
 /* =========================================================
+   TOOLBAR — Error Pages
+========================================================= */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+  padding: 12px 18px;
+  background: rgba(239, 68, 68, 0.04);
+  border: 1px solid rgba(239, 68, 68, 0.1);
+  border-radius: 20px;
+}
+
+.toolbar-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 200px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0 16px;
+  height: 40px;
+}
+
+.toolbar-search i {
+  color: #64748b;
+  font-size: 14px;
+}
+
+.toolbar-search input {
+  border: none;
+  outline: none;
+  background: transparent;
+  color: #fff;
+  font-size: 14px;
+  width: 100%;
+}
+
+.toolbar-search input::placeholder {
+  color: #475569;
+}
+
+.sort-dropdown-wrapper {
+  position: relative;
+}
+
+.sort-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 999px;
+  color: #fca5a5;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.sort-trigger:hover {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fff;
+}
+
+.sort-trigger.open {
+  background: rgba(239, 68, 68, 0.18);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #fff;
+}
+
+.sort-chevron {
+  font-size: 10px;
+  transition: transform 0.2s;
+}
+
+.sort-trigger.open .sort-chevron {
+  transform: rotate(180deg);
+}
+
+.sort-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  background: #1a1a2e;
+  border: 1px solid rgba(239, 68, 68, 0.15);
+  border-radius: 14px;
+  padding: 6px;
+  min-width: 160px;
+  z-index: 100;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+}
+
+.sort-menu.open {
+  display: block;
+}
+
+.sort-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #94a3b8;
+  transition: background 0.15s;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.sort-option:hover {
+  background: rgba(239, 68, 68, 0.08);
+  color: #fff;
+}
+
+.sort-option input[type="radio"] {
+  display: none;
+}
+
+.radio-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: border-color 0.2s;
+}
+
+.sort-option input[type="radio"]:checked ~ .radio-dot {
+  border-color: #ef4444;
+  background: #ef4444;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+}
+
+.sort-option input[type="radio"]:checked ~ .radio-dot::after {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff;
+}
+
+.sort-option:has(input[type="radio"]:checked) {
+  color: #fff;
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.results-count {
+  font-size: 13px;
+  color: #64748b;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+/* =========================================================
    MAIN CONTENT
 ========================================================= */
 

--- a/error.html
+++ b/error.html
@@ -350,6 +350,41 @@
     <p>Responsive modern error layouts, status screens, and application fallback pages.</p>
   </header>
 
+  <!-- SEARCH + SORT TOOLBAR -->
+  <div class="toolbar">
+    <div class="toolbar-search">
+      <i class="fa-solid fa-magnifying-glass"></i>
+      <input type="text" id="componentSearch" placeholder="Filter error components..." autocomplete="off">
+    </div>
+
+    <div class="sort-dropdown-wrapper" id="sortWrapper">
+      <button class="sort-trigger" id="sortTrigger" onclick="toggleSortMenu()">
+        <i class="fa-solid fa-arrow-up-arrow-down"></i>
+        <span id="sortLabel">Order</span>
+        <i class="fa-solid fa-chevron-down sort-chevron" id="sortChevron"></i>
+      </button>
+      <div class="sort-menu" id="sortMenu">
+        <label class="sort-option">
+          <span>Default</span>
+          <input type="radio" name="sort" value="default" checked onchange="sortCards('default')">
+          <span class="radio-dot"></span>
+        </label>
+        <label class="sort-option">
+          <span>A → Z</span>
+          <input type="radio" name="sort" value="az" onchange="sortCards('az')">
+          <span class="radio-dot"></span>
+        </label>
+        <label class="sort-option">
+          <span>Z → A</span>
+          <input type="radio" name="sort" value="za" onchange="sortCards('za')">
+          <span class="radio-dot"></span>
+        </label>
+      </div>
+    </div>
+
+    <span class="results-count" id="resultsCount">18 components</span>
+  </div>
+
   <section class="error-grid">
 
     <!-- 1. 404 ERROR PAGE -->
@@ -867,6 +902,71 @@
         }
       });
     });
+
+    // Toolbar: search + sort
+    function initToolbar() {
+      const input = document.getElementById('componentSearch');
+      const grid = document.querySelector('.error-grid');
+      const cards = [...grid.querySelectorAll('.error-card')];
+      const countEl = document.getElementById('resultsCount');
+      const originalOrder = [...cards];
+      let currentSort = 'default';
+
+      document.addEventListener('click', function(e) {
+        if (!document.getElementById('sortWrapper').contains(e.target)) {
+          closeSortMenu();
+        }
+      });
+
+      function update() {
+        const q = input.value.toLowerCase();
+
+        cards.forEach(card => {
+          const text = card.querySelector('h2').textContent.toLowerCase()
+                    + card.querySelector('p').textContent.toLowerCase();
+          card.style.display = text.includes(q) ? '' : 'none';
+        });
+
+        const visible = cards.filter(c => c.style.display !== 'none');
+        countEl.textContent = visible.length + ' component' + (visible.length === 1 ? '' : 's');
+
+        const sorted = [...visible].sort((a, b) => {
+          if (currentSort === 'default') return originalOrder.indexOf(a) - originalOrder.indexOf(b);
+          const ta = a.querySelector('h2').textContent;
+          const tb = b.querySelector('h2').textContent;
+          return currentSort === 'az' ? ta.localeCompare(tb) : tb.localeCompare(ta);
+        });
+
+        sorted.forEach(c => grid.appendChild(c));
+        cards.filter(c => c.style.display === 'none').forEach(c => grid.appendChild(c));
+      }
+
+      window.toggleSortMenu = function() {
+        const menu = document.getElementById('sortMenu');
+        const trigger = document.getElementById('sortTrigger');
+        const isOpen = menu.classList.contains('open');
+        menu.classList.toggle('open', !isOpen);
+        trigger.classList.toggle('open', !isOpen);
+      };
+
+      function closeSortMenu() {
+        document.getElementById('sortMenu').classList.remove('open');
+        document.getElementById('sortTrigger').classList.remove('open');
+      }
+
+      window.sortCards = function(dir) {
+        currentSort = dir;
+        const labels = { default: 'Order', az: 'A → Z', za: 'Z → A' };
+        document.getElementById('sortLabel').textContent = labels[dir];
+        closeSortMenu();
+        update();
+      };
+
+      input.addEventListener('input', update);
+      update();
+    }
+
+    initToolbar();
   });
 </script>
 


### PR DESCRIPTION
…page

## Related Issue
Closes #2439

## Summary
Adds a filter and sort toolbar to the Error Page Components page, allowing users to quickly find components by name and reorder the grid.

## Changes Made
- Added a live text filter input that hides non-matching error page cards in real time
- Added a sort dropdown (Default / A→Z / Z→A) with radio button selection
- Snapshots original DOM order on load, so "Default" always restores the authoring order
- Trigger button label updates to reflect the active sort state
- Dropdown closes on outside click
- Live component count updates as the user filters

## Testing
- Opened `error.html` locally in the browser
- Typed in the filter input and confirmed that only matching cards are shown, and the count updates
- Cycled through all three sort options and verified that cards were reordered correctly
- Verified "Default" restores the original page order
- Confirmed the dropdown closes when clicking outside it
- Checked no layout breakage on smaller viewport widths

## Screenshots
<img width="1901" height="1079" alt="UI screenshot of Error Page Components Page showing search and sort options" src="https://github.com/user-attachments/assets/e0232357-0ae0-49c2-9c1b-346ff1d06d40" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [ ] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)