### PR TITLE
compare.js: Guard against duplicate overlay creation + event handler …

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -17,6 +17,7 @@
   let reconcileQueued = false;
   let pendingActiveCell = undefined;
   let syncRetryQueued = false;
+  let keyDownBound = false;
 
   function getCardElements() {
     return Array.from(document.querySelectorAll(CARD_SELECTOR));
@@ -264,7 +265,7 @@
 
       closeBtn.addEventListener('click', () => closeOverlayKeepSelection());
 
-      document.addEventListener('keydown', onKeyDown);
+      bindOverlayKeydown();
     }
 
     const grid = document.getElementById(OVERLAY_GRID_ID);
@@ -292,9 +293,25 @@
     }
   }
 
+  function bindOverlayKeydown() {
+    if (keyDownBound) return;
+    document.addEventListener('keydown', onKeyDown);
+    keyDownBound = true;
+  }
+
+  function unbindOverlayKeydown() {
+    if (!keyDownBound) return;
+    document.removeEventListener('keydown', onKeyDown);
+    keyDownBound = false;
+  }
+
   function closeOverlayKeepSelection() {
+    unbindOverlayKeydown();
     const overlay = document.getElementById(OVERLAY_ID);
-    if (!overlay) return;
+    if (!overlay) {
+      state.overlayOpen = false;
+      return;
+    }
     syncActive(null);
     overlay.classList.remove('uiverse-compare-overlay--open');
     state.overlayOpen = false;


### PR DESCRIPTION
I added a module-level `keyDownBound` guard in compare.js, routed overlay setup through `bindOverlayKeydown()` in compare.js, and unbound Escape handling during close cleanup in compare.js. That keeps the compare overlay from stacking duplicate document listeners if the overlay lifecycle is hit more than once.

Validation: get_errors reported no errors for compare.js.

closes  #2473