### PR TITLE
Fix (OTP): "Neon OTP" text color

### DIFF
--- a/otp.css
+++ b/otp.css
@@ -392,6 +392,9 @@ body{
   background:#050816;
   color:white;
 }
+.neon-card h2{
+  color: #111;
+}
 
 .neon-otp{
   display:flex;
@@ -414,6 +417,7 @@ body{
 
   font-size:28px;
   font-weight:700;
+  font-family: consolas;
 
   outline:none;
 

--- a/otp.html
+++ b/otp.html
@@ -215,12 +215,12 @@
           <span>Authentication</span>
         </a>
       </li>
-        <li>
-          <a href="recovery.html">
-            <i class="fa-solid fa-key" aria-hidden="true"></i>
-            <span>Password Recovery</span>
-          </a>
-        </li>
+      <li class="active">
+        <a href="otp.html">
+          <i class="fa-solid fa-key"></i>
+          <span>OTP</span>
+        </a>
+      </li>
       <li>
         <a href="section.html">
           <i class="fa-solid fa-rectangle-list"></i>


### PR DESCRIPTION
## Related Issue
Closes #2557 

## Summary
On the OTP components page (`otp.html`), the "Neon OTP" text was white, and the background was white as well. Changed the text color to `#111`, matching the rest of the components.
 
## Screenshots
<img width="1578" height="418" alt="image" src="https://github.com/user-attachments/assets/af4f0334-eb81-485b-b5a0-82e61add2967" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [ ] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)