### PR TITLE
Feat(radio): Add 5 New Radio Button Components

### DIFF
--- a/radiobutton.css
+++ b/radiobutton.css
@@ -1155,6 +1155,332 @@ body {
 }
 
 /* =========================================================
+   COLOR SWATCH RADIO
+========================================================= */
+.swatch-radio-group {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.swatch-radio {
+  position: relative;
+  cursor: pointer;
+}
+.swatch-radio input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.swatch-dot {
+  display: block;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  transition: transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.25s;
+}
+.swatch-radio input:checked ~ .swatch-dot {
+  transform: scale(1.18);
+  box-shadow: 0 0 0 3px #0b0f1a, 0 0 0 5px var(--swatch-color, #6366f1);
+  outline: none;
+}
+/* Set --swatch-color per swatch via JS or leave as-is — the border adopts the bg colour */
+.swatch-radio:nth-child(1) input:checked ~ .swatch-dot { box-shadow: 0 0 0 3px #0b0f1a, 0 0 0 5px #6366f1; }
+.swatch-radio:nth-child(2) input:checked ~ .swatch-dot { box-shadow: 0 0 0 3px #0b0f1a, 0 0 0 5px #10b981; }
+.swatch-radio:nth-child(3) input:checked ~ .swatch-dot { box-shadow: 0 0 0 3px #0b0f1a, 0 0 0 5px #f97316; }
+.swatch-radio:nth-child(4) input:checked ~ .swatch-dot { box-shadow: 0 0 0 3px #0b0f1a, 0 0 0 5px #ec4899; }
+.swatch-radio:nth-child(5) input:checked ~ .swatch-dot { box-shadow: 0 0 0 3px #0b0f1a, 0 0 0 5px #eab308; }
+
+/* =========================================================
+   ADDRESS / HORIZONTAL CARD RADIO
+========================================================= */
+.hcard-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  max-width: 280px;
+}
+.hcard-radio {
+  position: relative;
+  cursor: pointer;
+  display: block;
+}
+.hcard-radio input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.hcard-inner {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 13px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.07);
+  background: rgba(255,255,255,0.03);
+  transition: all 0.3s;
+}
+.hcard-radio:hover .hcard-inner {
+  background: rgba(255,255,255,0.06);
+}
+.hcard-radio input:checked ~ .hcard-inner {
+  border-color: #6366f1;
+  background: rgba(99,102,241,0.08);
+}
+.hcard-inner > i {
+  font-size: 18px;
+  color: #64748b;
+  width: 22px;
+  text-align: center;
+  transition: color 0.3s;
+  flex-shrink: 0;
+}
+.hcard-radio input:checked ~ .hcard-inner > i {
+  color: #818cf8;
+}
+.hcard-text {
+  flex: 1;
+}
+.hcard-text strong {
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  color: #e2e8f0;
+}
+.hcard-text span {
+  font-size: 11px;
+  color: #64748b;
+}
+.hcard-pip {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid #475569;
+  transition: all 0.3s;
+  flex-shrink: 0;
+}
+.hcard-radio input:checked ~ .hcard-inner .hcard-pip {
+  background: #6366f1;
+  border-color: #6366f1;
+  box-shadow: 0 0 8px rgba(99,102,241,0.5);
+}
+
+/* =========================================================
+   STAR RATING RADIO
+========================================================= */
+.star-radio-group {
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+}
+.star-radio {
+  position: relative;
+  cursor: pointer;
+}
+.star-radio input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.star-radio i {
+  font-size: 32px;
+  color: #334155;
+  transition: color 0.2s, transform 0.2s;
+  display: block;
+}
+
+/* Hover: fill hovered star and all before it */
+.star-radio-group:hover .star-radio i {
+  color: #334155;
+}
+.star-radio:hover i,
+.star-radio:hover ~ .star-radio i {
+  color: #334155;
+}
+.star-radio-group .star-radio:hover i,
+.star-radio-group .star-radio:hover ~ .star-radio i {
+  color: #334155 !important;
+}
+
+/* Fill stars up to and including hovered one */
+.star-radio-group:has(.star-radio:nth-child(1):hover) .star-radio:nth-child(1) i { color: #eab308 !important; }
+
+.star-radio-group:has(.star-radio:nth-child(2):hover) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(2):hover) .star-radio:nth-child(2) i { color: #eab308 !important; }
+
+.star-radio-group:has(.star-radio:nth-child(3):hover) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(3):hover) .star-radio:nth-child(2) i,
+.star-radio-group:has(.star-radio:nth-child(3):hover) .star-radio:nth-child(3) i { color: #eab308 !important; }
+
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(2) i,
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(3) i,
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(4) i { color: #eab308 !important; }
+
+.star-radio-group:has(.star-radio:nth-child(5):hover) .star-radio i { color: #eab308 !important; }
+
+/* Checked: fill stars up to and including selected one */
+.star-radio-group:has(.star-radio:nth-child(1) input:checked) .star-radio:nth-child(1) i { color: #eab308; }
+
+.star-radio-group:has(.star-radio:nth-child(2) input:checked) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(2) input:checked) .star-radio:nth-child(2) i { color: #eab308; }
+
+.star-radio-group:has(.star-radio:nth-child(3) input:checked) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(3) input:checked) .star-radio:nth-child(2) i,
+.star-radio-group:has(.star-radio:nth-child(3) input:checked) .star-radio:nth-child(3) i { color: #eab308; }
+
+.star-radio-group:has(.star-radio:nth-child(4) input:checked) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(4) input:checked) .star-radio:nth-child(2) i,
+.star-radio-group:has(.star-radio:nth-child(4) input:checked) .star-radio:nth-child(3) i,
+.star-radio-group:has(.star-radio:nth-child(4) input:checked) .star-radio:nth-child(4) i { color: #eab308; }
+
+.star-radio-group:has(.star-radio:nth-child(5) input:checked) .star-radio i { color: #eab308; }
+
+/* Hover overrides checked state visually */
+.star-radio-group:hover .star-radio i {
+  color: #334155;
+}
+.star-radio-group:has(.star-radio:nth-child(1):hover) .star-radio:nth-child(1) i { color: #eab308 !important; }
+.star-radio-group:has(.star-radio:nth-child(2):hover) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(2):hover) .star-radio:nth-child(2) i { color: #eab308 !important; }
+.star-radio-group:has(.star-radio:nth-child(3):hover) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(3):hover) .star-radio:nth-child(2) i,
+.star-radio-group:has(.star-radio:nth-child(3):hover) .star-radio:nth-child(3) i { color: #eab308 !important; }
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(1) i,
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(2) i,
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(3) i,
+.star-radio-group:has(.star-radio:nth-child(4):hover) .star-radio:nth-child(4) i { color: #eab308 !important; }
+.star-radio-group:has(.star-radio:nth-child(5):hover) .star-radio i { color: #eab308 !important; }
+/* =========================================================
+   PILL CHIP RADIO
+========================================================= */
+.chip-radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+.chip-radio {
+  position: relative;
+  cursor: pointer;
+}
+.chip-radio input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.chip-radio span {
+  display: block;
+  padding: 9px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: #94a3b8;
+  font-size: 13px;
+  font-weight: 600;
+  transition: all 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+.chip-radio:hover span {
+  background: rgba(255,255,255,0.08);
+  color: #e2e8f0;
+}
+.chip-radio input:checked ~ span {
+  background: #6366f1;
+  color: #fff;
+  border-color: #6366f1;
+  box-shadow: 0 4px 14px rgba(99,102,241,0.35);
+  transform: translateY(-2px);
+}
+
+/* =========================================================
+   THEME MODE RADIO
+========================================================= */
+.theme-radio-group {
+  display: flex;
+  gap: 12px;
+}
+.theme-radio {
+  position: relative;
+  cursor: pointer;
+  flex: 1;
+}
+.theme-radio input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.theme-card-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 18px 10px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.08);
+  transition: all 0.3s;
+  position: relative;
+}
+.theme-light-card {
+  background: rgba(255,255,255,0.08);
+}
+.theme-dark-card {
+  background: rgba(10,10,20,0.5);
+}
+.theme-auto-card {
+  background: rgba(99,102,241,0.07);
+}
+.theme-card-inner i {
+  font-size: 22px;
+  color: #94a3b8;
+  transition: color 0.3s;
+}
+.theme-card-inner span {
+  font-size: 12px;
+  font-weight: 700;
+  color: #64748b;
+  transition: color 0.3s;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.theme-check {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #6366f1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+.theme-check i {
+  font-size: 9px !important;
+  color: white !important;
+}
+.theme-radio:hover .theme-card-inner {
+  border-color: rgba(255,255,255,0.15);
+}
+.theme-radio input:checked ~ .theme-card-inner {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99,102,241,0.25);
+}
+.theme-radio input:checked ~ .theme-card-inner i {
+  color: #818cf8;
+}
+.theme-radio input:checked ~ .theme-card-inner span {
+  color: #c7d2fe;
+}
+.theme-radio input:checked ~ .theme-card-inner .theme-check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* =========================================================
    SIDEBAR (mirrored from project standard)
 ========================================================= */
 .sidebar {

--- a/radiobutton.html
+++ b/radiobutton.html
@@ -740,7 +740,7 @@
           </label>
           <label class="icon-radio">
             <input type="radio" name="icon" checked>
-            <i class="fa-solid fa-bluetooth"></i>
+            <i class="fa-brands fa-bluetooth-b"></i>
           </label>
           <label class="icon-radio">
             <input type="radio" name="icon">
@@ -857,6 +857,268 @@
   &lt;span class="inline-dot"&gt;&lt;/span&gt;
   &lt;span&gt;Yes&lt;/span&gt;
 &lt;/label&gt;</code></pre>
+    </div>
+
+    <!-- ============ COMPONENT: COLOR SWATCH RADIO ============ -->
+    <style>
+      .swatch-dot.indigo { background: #6366f1; }
+      .swatch-dot.green { background: #10b981; }
+      .swatch-dot.orange { background: #f97316; }
+      .swatch-dot.pink { background: #ec4899; }
+      .swatch-dot.yellow { background: #eab308; }
+    </style>
+
+    <div class="component-card">
+      <div class="card-preview">
+        <div class="swatch-radio-group">
+          <label class="swatch-radio">
+            <input type="radio" name="swatch" checked title="Indigo" aria-label="Indigo">
+            <span class="swatch-dot indigo"></span>
+          </label>
+          <label class="swatch-radio">
+            <input type="radio" name="swatch" title="Green" aria-label="Green">
+            <span class="swatch-dot green"></span>
+          </label>
+          <label class="swatch-radio">
+            <input type="radio" name="swatch" title="Orange" aria-label="Orange">
+            <span class="swatch-dot orange"></span>
+          </label>
+          <label class="swatch-radio">
+            <input type="radio" name="swatch" title="Pink" aria-label="Pink">
+            <span class="swatch-dot pink"></span>
+          </label>
+          <label class="swatch-radio">
+            <input type="radio" name="swatch" title="Yellow" aria-label="Yellow">
+            <span class="swatch-dot yellow"></span>
+          </label>
+        </div>
+      </div>
+      <div class="card-content">
+        <div class="card-top">
+          <h3>Color Swatch Radio</h3>
+          <span>Picker</span>
+        </div>
+        <p>Circular colour swatch radio selector — ideal for theme or palette pickers with a ring highlight on selection.</p>
+        <div class="card-actions">
+          <button type="button" onclick="toggleCode('r16')"><i class="fa-solid fa-code"></i> View Code</button>
+          <button type="button" onclick="copyCode('r16')"><i class="fa-solid fa-copy"></i> Copy</button>
+          <button type="button"><i class="fa-solid fa-bookmark"></i> Save</button>
+        </div>
+      </div>
+      <pre id="r16" class="code-block" style="display:none;"><code>&lt;label class="swatch-radio"&gt;
+      &lt;input type="radio" name="swatch" checked&gt;
+      &lt;span class="swatch-dot indigo"&gt;&lt;/span&gt;
+    &lt;/label&gt;
+
+    .swatch-radio input:checked ~ .swatch-dot {
+      box-shadow: 0 0 0 3px #0b0f1a, 0 0 0 5px currentColor;
+      transform: scale(1.15);
+    }</code></pre>
+    </div>
+
+    <!-- ============ COMPONENT: HORIZONTAL CARD RADIO ============ -->
+    <div class="component-card">
+      <div class="card-preview">
+        <div class="hcard-radio-group">
+          <label class="hcard-radio">
+            <input type="radio" name="hcard" checked>
+            <div class="hcard-inner">
+              <i class="fa-solid fa-house"></i>
+              <div class="hcard-text">
+                <strong>Home</strong>
+                <span>123 Main St</span>
+              </div>
+              <div class="hcard-pip"></div>
+            </div>
+          </label>
+          <label class="hcard-radio">
+            <input type="radio" name="hcard">
+            <div class="hcard-inner">
+              <i class="fa-solid fa-building"></i>
+              <div class="hcard-text">
+                <strong>Office</strong>
+                <span>456 Work Ave</span>
+              </div>
+              <div class="hcard-pip"></div>
+            </div>
+          </label>
+          <label class="hcard-radio">
+            <input type="radio" name="hcard">
+            <div class="hcard-inner">
+              <i class="fa-solid fa-location-dot"></i>
+              <div class="hcard-text">
+                <strong>Other</strong>
+                <span>Custom address</span>
+              </div>
+              <div class="hcard-pip"></div>
+            </div>
+          </label>
+        </div>
+      </div>
+      <div class="card-content">
+        <div class="card-top">
+          <h3>Address Radio Card</h3>
+          <span>Delivery</span>
+        </div>
+        <p>Horizontal card radio for selecting saved addresses or delivery locations with icon, label, and animated pip.</p>
+        <div class="card-actions">
+          <button type="button" onclick="toggleCode('r17')"><i class="fa-solid fa-code"></i> View Code</button>
+          <button type="button" onclick="copyCode('r17')"><i class="fa-solid fa-copy"></i> Copy</button>
+          <button type="button"><i class="fa-solid fa-bookmark"></i> Save</button>
+        </div>
+      </div>
+      <pre id="r17" class="code-block" style="display:none;"><code>&lt;label class="hcard-radio"&gt;
+      &lt;input type="radio" name="hcard" checked&gt;
+      &lt;div class="hcard-inner"&gt;
+        &lt;i class="fa-solid fa-house"&gt;&lt;/i&gt;
+        &lt;div class="hcard-text"&gt;
+          &lt;strong&gt;Home&lt;/strong&gt;
+          &lt;span&gt;123 Main St&lt;/span&gt;
+        &lt;/div&gt;
+        &lt;div class="hcard-pip"&gt;&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/label&gt;
+
+    .hcard-radio input:checked ~ .hcard-inner {
+      border-color: #6366f1;
+      background: rgba(99,102,241,0.08);
+    }
+    .hcard-radio input:checked ~ .hcard-inner .hcard-pip {
+      background: #6366f1;
+      box-shadow: 0 0 8px rgba(99,102,241,0.5);
+    }</code></pre>
+    </div>
+
+    <!-- ============ COMPONENT: STAR RATING RADIO ============ -->
+    <div class="component-card">
+      <div class="card-preview">
+        <div class="star-radio-group">
+          <label class="star-radio"><input type="radio" name="star" value="1" aria-label="1 star"><i class="fa-solid fa-star"></i></label>
+          <label class="star-radio"><input type="radio" name="star" value="2" aria-label="2 stars"><i class="fa-solid fa-star"></i></label>
+          <label class="star-radio"><input type="radio" name="star" value="3" checked aria-label="3 stars"><i class="fa-solid fa-star"></i></label>
+          <label class="star-radio"><input type="radio" name="star" value="4" aria-label="4 stars"><i class="fa-solid fa-star"></i></label>
+          <label class="star-radio"><input type="radio" name="star" value="5" aria-label="5 stars"><i class="fa-solid fa-star"></i></label>
+        </div>
+      </div>
+      <div class="card-content">
+        <div class="card-top">
+          <h3>Star Rating Radio</h3>
+          <span>Rating</span>
+        </div>
+        <p>Classic five-star rating implemented as a pure CSS radio group with a hover fill-cascade effect.</p>
+        <div class="card-actions">
+          <button type="button" onclick="toggleCode('r18')"><i class="fa-solid fa-code"></i> View Code</button>
+          <button type="button" onclick="copyCode('r18')"><i class="fa-solid fa-copy"></i> Copy</button>
+          <button type="button"><i class="fa-solid fa-bookmark"></i> Save</button>
+        </div>
+      </div>
+      <pre id="r18" class="code-block" style="display:none;"><code>&lt;div class="star-radio-group"&gt;
+      &lt;label class="star-radio"&gt;&lt;input type="radio" name="star" value="1"&gt;&lt;i class="fa-solid fa-star"&gt;&lt;/i&gt;&lt;/label&gt;
+      &lt;label class="star-radio"&gt;&lt;input type="radio" name="star" value="2"&gt;&lt;i class="fa-solid fa-star"&gt;&lt;/i&gt;&lt;/label&gt;
+      &lt;label class="star-radio"&gt;&lt;input type="radio" name="star" value="3"&gt;&lt;i class="fa-solid fa-star"&gt;&lt;/i&gt;&lt;/label&gt;
+      &lt;label class="star-radio"&gt;&lt;input type="radio" name="star" value="4"&gt;&lt;i class="fa-solid fa-star"&gt;&lt;/i&gt;&lt;/label&gt;
+      &lt;label class="star-radio"&gt;&lt;input type="radio" name="star" value="5"&gt;&lt;i class="fa-solid fa-star"&gt;&lt;/i&gt;&lt;/label&gt;
+    &lt;/div&gt;
+
+    .star-radio-group { direction: rtl; }
+    .star-radio i { color: #334155; transition: color .2s; }
+    .star-radio:hover ~ .star-radio i,
+    .star-radio:hover i { color: #eab308; }</code></pre>
+    </div>
+
+    <!-- ============ COMPONENT: PILL CHIP RADIO ============ -->
+    <div class="component-card">
+      <div class="card-preview">
+        <div class="chip-radio-group">
+          <label class="chip-radio"><input type="radio" name="chip" checked><span>Design</span></label>
+          <label class="chip-radio"><input type="radio" name="chip"><span>Engineering</span></label>
+          <label class="chip-radio"><input type="radio" name="chip"><span>Marketing</span></label>
+          <label class="chip-radio"><input type="radio" name="chip"><span>Product</span></label>
+        </div>
+      </div>
+      <div class="card-content">
+        <div class="card-top">
+          <h3>Pill Chip Radio</h3>
+          <span>Filter</span>
+        </div>
+        <p>Tag-style pill chips as radio buttons — perfect for category filters, tags, and preference selectors.</p>
+        <div class="card-actions">
+          <button type="button" onclick="toggleCode('r19')"><i class="fa-solid fa-code"></i> View Code</button>
+          <button type="button" onclick="copyCode('r19')"><i class="fa-solid fa-copy"></i> Copy</button>
+          <button type="button"><i class="fa-solid fa-bookmark"></i> Save</button>
+        </div>
+      </div>
+      <pre id="r19" class="code-block" style="display:none;"><code>&lt;label class="chip-radio"&gt;
+      &lt;input type="radio" name="chip" checked&gt;
+      &lt;span&gt;Design&lt;/span&gt;
+    &lt;/label&gt;
+
+    .chip-radio input:checked ~ span {
+      background: #6366f1;
+      color: #fff;
+      border-color: #6366f1;
+    }</code></pre>
+    </div>
+
+    <!-- ============ COMPONENT: DARK/LIGHT THEME RADIO ============ -->
+    <div class="component-card">
+      <div class="card-preview">
+        <div class="theme-radio-group">
+          <label class="theme-radio">
+            <input type="radio" name="thememode" checked>
+            <div class="theme-card-inner theme-light-card">
+              <i class="fa-solid fa-sun"></i>
+              <span>Light</span>
+              <div class="theme-check"><i class="fa-solid fa-check"></i></div>
+            </div>
+          </label>
+          <label class="theme-radio">
+            <input type="radio" name="thememode">
+            <div class="theme-card-inner theme-dark-card">
+              <i class="fa-solid fa-moon"></i>
+              <span>Dark</span>
+              <div class="theme-check"><i class="fa-solid fa-check"></i></div>
+            </div>
+          </label>
+          <label class="theme-radio">
+            <input type="radio" name="thememode">
+            <div class="theme-card-inner theme-auto-card">
+              <i class="fa-solid fa-circle-half-stroke"></i>
+              <span>Auto</span>
+              <div class="theme-check"><i class="fa-solid fa-check"></i></div>
+            </div>
+          </label>
+        </div>
+      </div>
+      <div class="card-content">
+        <div class="card-top">
+          <h3>Theme Mode Radio</h3>
+          <span>Settings</span>
+        </div>
+        <p>Visual theme selector with icon cards for Light, Dark, and Auto modes — great for settings panels.</p>
+        <div class="card-actions">
+          <button type="button" onclick="toggleCode('r20')"><i class="fa-solid fa-code"></i> View Code</button>
+          <button type="button" onclick="copyCode('r20')"><i class="fa-solid fa-copy"></i> Copy</button>
+          <button type="button"><i class="fa-solid fa-bookmark"></i> Save</button>
+        </div>
+      </div>
+      <pre id="r20" class="code-block" style="display:none;"><code>&lt;label class="theme-radio"&gt;
+      &lt;input type="radio" name="thememode" checked&gt;
+      &lt;div class="theme-card-inner theme-light-card"&gt;
+        &lt;i class="fa-solid fa-sun"&gt;&lt;/i&gt;
+        &lt;span&gt;Light&lt;/span&gt;
+        &lt;div class="theme-check"&gt;&lt;i class="fa-solid fa-check"&gt;&lt;/i&gt;&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/label&gt;
+
+    .theme-radio input:checked ~ .theme-card-inner {
+      border-color: #6366f1;
+      box-shadow: 0 0 0 2px rgba(99,102,241,0.25);
+    }
+    .theme-radio input:checked ~ .theme-card-inner .theme-check {
+      opacity: 1;
+      transform: scale(1);
+    }</code></pre>
     </div>
 
   </section>


### PR DESCRIPTION
## Related Issue
Closes #2734 

## Summary
Adds 5 new radio button components to the UIverse radio button page.

## New components
- Color Swatch Radio: circular palette picker with per-colour ring highlight
- Address Card Radio: horizontal card layout for saved delivery/address selection
- Star Rating Radio: five-star selector with CSS-only fill cascade using :has()
- Pill Chip Radio: tag-style filter chips with lift animation on selection
- Theme Mode Radio: icon cards for Light / Dark / Auto with animated checkmark badge

## Screenshots
<img width="1438" height="725" alt="image" src="https://github.com/user-attachments/assets/19158faf-7075-4b9c-a674-30f1ac4f33b4" />
<img width="980" height="696" alt="image" src="https://github.com/user-attachments/assets/f126cd4d-005d-48b1-bbc0-93d35c084cf6" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [ ] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)