### PR TITLE
fix: add missing aria-labels to social icons in about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -427,9 +427,9 @@
     </nav>
 
     <div class="sidebar-footer">
-      <a href="#"><i class="fab fa-github"></i></a>
-      <a href="#"><i class="fab fa-linkedin"></i></a>
-      <a href="#"><i class="fab fa-x-twitter"></i></a>
+      <a href="#" aria-label="GitHub"><i class="fab fa-github"></i></a>
+      <a href="#" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+      <a href="#" aria-label="Twitter"><i class="fab fa-x-twitter"></i></a>
     </div>
 
   </aside>


### PR DESCRIPTION
# Related Issue
Closes #2911 

# Summary
This PR improves the accessibility of the `about.html` page by adding missing `aria-label` attributes to icon-only social links in the sidebar footer.

# Changes Made
* Added `aria-label="GitHub"` to the GitHub social icon link.
* Added `aria-label="LinkedIn"` to the LinkedIn social icon link.
* Added `aria-label="Twitter"` to the Twitter/X social icon link.

# Testing
* [x] Tested locally
* [x] Verified links are correctly identified by screen readers.
* [x] Code follows project style
* [x] No unrelated changes included
