### PR TITLE
style: replace emojis with icons on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
 
   <!-- ===== HERO ===== -->
   <section class="hero">
-    <div class="hero-badge">🚀 v2.0 — Now with 120+ components</div>
+    <div class="hero-badge"><i class="fa-solid fa-rocket"></i> v2.0 — Now with 120+ components</div>
 
     <h1 class="hero-title">
       Build <span class="hero-accent">beautiful UIs</span><br>
@@ -439,14 +439,14 @@
   <section class="section featured-section">
     <div class="section-header">
       <span class="section-tag">Most Loved</span>
-      <h2 class="section-title">⭐ Popular Components</h2>
+      <h2 class="section-title"><i class="fa-solid fa-star"></i> Popular Components</h2>
       <p class="section-subtitle">Handpicked favorites from developers worldwide</p>
     </div>
 
     <div class="featured-cards">
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #ff6b6b;">🎯</div>
+        <div class="feature-icon-wrap" style="--icon-color: #ff6b6b;"><i class="fa-solid fa-bullseye"></i></div>
         <div class="feature-card-body">
           <h3>Gradient Button</h3>
           <p>Modern colorful buttons with smooth gradient design.</p>
@@ -459,7 +459,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #74b9ff;">🎨</div>
+        <div class="feature-icon-wrap" style="--icon-color: #74b9ff;"><i class="fa-solid fa-palette"></i></div>
         <div class="feature-card-body">
           <h3>Glass Navbar</h3>
           <p>Transparent blurred navigation bar with modern aesthetics.</p>
@@ -471,7 +471,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #55efc4;">📦</div>
+        <div class="feature-icon-wrap" style="--icon-color: #55efc4;"><i class="fa-solid fa-box"></i></div>
         <div class="feature-card-body">
           <h3>Card UI</h3>
           <p>Clean and reusable card layout for content display.</p>
@@ -483,7 +483,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #fdcb6e;">⚡</div>
+        <div class="feature-icon-wrap" style="--icon-color: #fdcb6e;"><i class="fa-solid fa-bolt"></i></div>
         <div class="feature-card-body">
           <h3>Spinner Loaders</h3>
           <p>Smooth loading animations for better UX.</p>
@@ -495,7 +495,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #a29bfe;">💰</div>
+        <div class="feature-icon-wrap" style="--icon-color: #a29bfe;"><i class="fa-solid fa-sack-dollar"></i></div>
         <div class="feature-card-body">
           <h3>Pricing Cards</h3>
           <p>Professional pricing sections for SaaS products.</p>
@@ -507,7 +507,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #fd79a8;">🔔</div>
+        <div class="feature-icon-wrap" style="--icon-color: #fd79a8;"><i class="fa-solid fa-bell"></i></div>
         <div class="feature-card-body">
           <h3>Alert Boxes</h3>
           <p>Responsive alert components for notifications.</p>
@@ -519,7 +519,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #4ecdc4;">🌾</div>
+        <div class="feature-icon-wrap" style="--icon-color: #4ecdc4;"><i class="fa-solid fa-wheat-awn"></i></div>
         <div class="feature-card-body">
           <h3>Crop ROI Lab</h3>
           <p>Predict yield, revenue, and return on investment for the next harvest cycle.</p>
@@ -532,7 +532,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #86c06a;">📦</div>
+        <div class="feature-icon-wrap" style="--icon-color: #86c06a;"><i class="fa-solid fa-box-open"></i></div>
         <div class="feature-card-body">
           <h3>Produce Traceability</h3>
           <p>Generate a QR code for each batch and verify the full farm-to-shelf timeline.</p>
@@ -545,7 +545,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #2f6f9f;">📡</div>
+        <div class="feature-icon-wrap" style="--icon-color: #2f6f9f;"><i class="fa-solid fa-satellite-dish"></i></div>
         <div class="feature-card-body">
           <h3>IoT Sensor Hub</h3>
           <p>Track moisture, temperature, humidity, and nutrient levels from connected farm sensors.</p>
@@ -558,7 +558,7 @@
       </div>
 
       <div class="feature-card">
-        <div class="feature-icon-wrap" style="--icon-color: #d97706;">🚜</div>
+        <div class="feature-icon-wrap" style="--icon-color: #d97706;"><i class="fa-solid fa-tractor"></i></div>
         <div class="feature-card-body">
           <h3>Equipment Marketplace</h3>
           <p>Share tractors and heavy machinery with neighboring farms through a rental marketplace.</p>
@@ -577,78 +577,78 @@
   <section class="section categories-section">
     <div class="section-header">
       <span class="section-tag">Browse All</span>
-      <h2 class="section-title">📦 Explore Categories</h2>
+      <h2 class="section-title"><i class="fa-solid fa-boxes-stacked"></i> Explore Categories</h2>
     </div>
 
     <div class="categories-grid">
       <a href="button.html" class="cat-card">
-        <div class="cat-icon">🔘</div>
+        <div class="cat-icon"><i class="fa-solid fa-circle-dot"></i></div>
         <h3>Buttons</h3>
         <p>Interactive button styles</p>
         <span class="cat-count">24 items</span>
       </a>
       <a href="navbar.html" class="cat-card">
-        <div class="cat-icon">☰</div>
+        <div class="cat-icon"><i class="fa-solid fa-bars"></i></div>
         <h3>Navbars</h3>
         <p>Navigation UI components</p>
         <span class="cat-count">12 items</span>
       </a>
       <a href="cards.html" class="cat-card">
-        <div class="cat-icon">🃏</div>
+        <div class="cat-icon"><i class="fa-solid fa-layer-group"></i></div>
         <h3>Cards</h3>
         <p>Flexible card layouts</p>
         <span class="cat-count">18 items</span>
       </a>
       <a href="inputs.html" class="cat-card">
-        <div class="cat-icon">⌨️</div>
+        <div class="cat-icon"><i class="fa-solid fa-keyboard"></i></div>
         <h3>Inputs</h3>
         <p>Forms & input fields</p>
         <span class="cat-count">20 items</span>
       </a>
       <a href="forms.html" class="cat-card">
-        <div class="cat-icon">📋</div>
+        <div class="cat-icon"><i class="fa-solid fa-clipboard-list"></i></div>
         <h3>Forms</h3>
         <p>Complete form templates</p>
         <span class="cat-count">10 items</span>
       </a>
       <a href="roi_dashboard.html" class="cat-card">
-        <div class="cat-icon">🌾</div>
+        <div class="cat-icon"><i class="fa-solid fa-wheat-awn"></i></div>
         <h3>Finance Tools</h3>
         <p>Predict crop ROI and yield</p>
         <span class="cat-count">1 dashboard</span>
       </a>
       <a href="trace.html" class="cat-card">
-        <div class="cat-icon">📦</div>
+        <div class="cat-icon"><i class="fa-solid fa-box"></i></div>
         <h3>Traceability</h3>
         <p>QR code and ledger verification</p>
         <span class="cat-count">2 pages</span>
       </a>
       <a href="farm_dashboard.html" class="cat-card">
-        <div class="cat-icon">📡</div>
+        <div class="cat-icon"><i class="fa-solid fa-satellite-dish"></i></div>
         <h3>IoT Hub</h3>
         <p>Realtime sensor telemetry</p>
         <span class="cat-count">2 pages</span>
       </a>
       <a href="equipment.html" class="cat-card">
-        <div class="cat-icon">🚜</div>
+        <div class="cat-icon"><i class="fa-solid fa-tractor"></i></div>
         <h3>Equipment</h3>
         <p>Rental listings and booking</p>
         <span class="cat-count">2 pages</span>
       </a>
       <a href="badges.html" class="cat-card">
-        <div class="cat-icon">🏅</div>
+        <div class="cat-icon"><i class="fa-solid fa-medal"></i></div>
         <h3>Badges</h3>
         <p>Labels, tags & badges</p>
         <span class="cat-count">15 items</span>
       </a>
       <a href="color.html" class="cat-card">
-        <div class="cat-icon">🎨</div>
+        <div class="cat-icon"><i class="fa-solid fa-palette"></i></div>
         <h3>Colors</h3>
         <p>Color palette & themes</p>
         <span class="cat-count">8 items</span>
       </a>
       <a href="footer.html" class="cat-card">
-        <div class="cat-icon">📄</div>
+        <div class="cat-icon"><i class="fa-solid fa-file-lines"></i></div>
         <h3>Footers</h3>
         <p>Footer section layouts</p>
         <span class="cat-count">9 items</span>
@@ -660,37 +660,37 @@
   <section class="section why-section">
     <div class="section-header">
       <span class="section-tag">Why choose us</span>
-      <h2 class="section-title">✨ Why UIverse?</h2>
+      <h2 class="section-title"><i class="fa-solid fa-wand-magic-sparkles"></i> Why UIverse?</h2>
     </div>
 
     <div class="why-grid">
       <div class="why-card">
-        <div class="why-icon">⚡</div>
+        <div class="why-icon"><i class="fa-solid fa-bolt"></i></div>
         <h3>Fast & Lightweight</h3>
         <p>Zero frameworks, zero dependencies. Pure HTML, CSS and JavaScript for blazing fast performance.</p>
       </div>
       <div class="why-card">
-        <div class="why-icon">📱</div>
+        <div class="why-icon"><i class="fa-solid fa-mobile-screen"></i></div>
         <h3>Fully Responsive</h3>
         <p>Every component is built mobile-first and works seamlessly on any device or screen size.</p>
       </div>
       <div class="why-card">
-        <div class="why-icon">🎯</div>
+        <div class="why-icon"><i class="fa-solid fa-bullseye"></i></div>
         <h3>Beginner Friendly</h3>
         <p>Clean, well-commented code that's easy to understand, learn from, and customize.</p>
       </div>
       <div class="why-card">
-        <div class="why-icon">🛠</div>
+        <div class="why-icon"><i class="fa-solid fa-screwdriver-wrench"></i></div>
         <h3>Fully Customizable</h3>
         <p>Simple CSS variables make it trivial to adapt any component to match your brand.</p>
       </div>
       <div class="why-card">
-        <div class="why-icon">🤝</div>
+        <div class="why-icon"><i class="fa-solid fa-handshake"></i></div>
         <h3>Open Source</h3>
         <p>Everything is free and open source. Contribute, fork, or use however you like.</p>
       </div>
       <div class="why-card">
-        <div class="why-icon">🔄</div>
+        <div class="why-icon"><i class="fa-solid fa-rotate"></i></div>
         <h3>Regularly Updated</h3>
         <p>New components and improvements are added regularly. Stay ahead with the latest UI trends.</p>
       </div>
@@ -773,7 +773,7 @@
   </div>
 
   <div class="footer-bottom">
-    <p>© 2026 UIverse. Made with ❤️ for developers worldwide.</p>
+    <p>© 2026 UIverse. Made with <i class="fa-solid fa-heart" style="color: #ff4757;"></i> for developers worldwide.</p>
   </div>
 </footer>
 


### PR DESCRIPTION
# Related Issue
Closes #2913 

# Summary
Replaces all native emojis across the `index.html` page with scalable FontAwesome icons to ensure cross-platform consistency and a more professional aesthetic.

# Changes Made
* Replaced hero badge emoji (🚀) with `fa-rocket`.
* Replaced feature icons (🎯, 🎨, 📦, ⚡, 💰, 🔔, 🌾, 📡, 🚜) with their FontAwesome equivalents.
* Replaced category grid emojis with scalable icons.
* Replaced footer copyright heart emoji (❤️) with a styled FontAwesome heart icon.

# Testing
* [x] Tested locally
* [x] Code follows project style
* [x] No unrelated changes included
