### PR TITLE
fix: use h1 for error page headers

### DIFF
--- a/error.html
+++ b/error.html
@@ -396,7 +396,7 @@
       <div class="component-preview" id="preview-1">
         <div class="error-screen err-404">
           <div class="error-code">404</div>
-          <div class="error-title">Page Not Found</div>
+          <h1 class="error-title">Page Not Found</div>
           <div class="error-desc">The page you are looking for doesn't exist or has been moved.</div>
           <button class="error-btn">Go Back Home</button>
         </div>
@@ -417,7 +417,7 @@
       <div class="component-preview" id="preview-2">
         <div class="error-screen err-500">
           <div class="error-code">500</div>
-          <div class="error-title">Internal Server Error</div>
+          <h1 class="error-title">Internal Server Error</div>
           <div class="error-desc">Oops, something went wrong on our end. We are working to fix it.</div>
           <button class="error-btn">Try Again</button>
         </div>
@@ -438,7 +438,7 @@
       <div class="component-preview" id="preview-3">
         <div class="error-screen err-maint">
           <div class="icon-wrap"><i class="fa-solid fa-gear"></i></div>
-          <div class="error-title">Under Maintenance</div>
+          <h1 class="error-title">Under Maintenance</div>
           <div class="error-desc">We're upgrading our systems. Be right back!</div>
           <div class="progress-bar"><div class="progress-fill"></div></div>
         </div>
@@ -460,7 +460,7 @@
         <div class="error-screen err-403">
           <div class="icon-wrap"><i class="fa-solid fa-lock"></i></div>
           <div class="error-code" style="font-size:32px;">403</div>
-          <div class="error-title">Access Denied</div>
+          <h1 class="error-title">Access Denied</div>
           <div class="error-desc">You do not have permission to view this directory or page.</div>
           <button class="error-btn">Request Access</button>
         </div>
@@ -481,7 +481,7 @@
       <div class="component-preview" id="preview-5">
         <div class="error-screen err-net">
           <div class="icon-wrap"><i class="fa-solid fa-wifi"></i></div>
-          <div class="error-title">No Connection</div>
+          <h1 class="error-title">No Connection</div>
           <div class="error-desc">Please check your internet connection and try again.</div>
           <button class="error-btn">Retry Connection</button>
         </div>
@@ -502,7 +502,7 @@
       <div class="component-preview" id="preview-6">
         <div class="error-screen err-session">
           <div class="icon-wrap"><i class="fa-solid fa-hourglass-end"></i></div>
-          <div class="error-title">Session Expired</div>
+          <h1 class="error-title">Session Expired</div>
           <div class="error-desc">For your security, your session has timed out due to inactivity.</div>
           <button class="error-btn">Log In Again</button>
         </div>
@@ -523,7 +523,7 @@
       <div class="component-preview" id="preview-7">
         <div class="error-screen err-payment">
           <div class="icon-wrap"><i class="fa-solid fa-circle-exclamation"></i></div>
-          <div class="error-title">Payment Failed</div>
+          <h1 class="error-title">Payment Failed</div>
           <div class="error-desc">Your transaction could not be processed. Please check your card details or try again.</div>
           <div class="btn-group">
             <button class="error-btn btn-retry">Retry Payment</button>
@@ -547,7 +547,7 @@
       <div class="component-preview" id="preview-8">
         <div class="error-screen err-empty-search">
           <div class="icon-wrap"><i class="fa-solid fa-magnifying-glass"></i></div>
-          <div class="error-title">No Results Found</div>
+          <h1 class="error-title">No Results Found</div>
           <div class="error-desc">We couldn't find any matches. Try using more general keywords or checking spelling.</div>
           <button class="error-btn">Clear Search</button>
         </div>
@@ -568,7 +568,7 @@
       <div class="component-preview" id="preview-9">
         <div class="error-screen err-unauthorized">
           <div class="icon-wrap"><i class="fa-solid fa-shield-halved"></i></div>
-          <div class="error-title">Access Restricted</div>
+          <h1 class="error-title">Access Restricted</div>
           <div class="error-desc">This directory requires elevated credentials. Please sign in with an admin account.</div>
           <button class="error-btn">Request Access</button>
         </div>
@@ -589,7 +589,7 @@
       <div class="component-preview" id="preview-10">
         <div class="error-screen err-offline">
           <div class="icon-wrap"><i class="fa-solid fa-cloud-bolt"></i></div>
-          <div class="error-title">You're Offline</div>
+          <h1 class="error-title">You're Offline</div>
           <div class="error-desc">It looks like you've lost connection. Check your local connection or try reloading.</div>
           <button class="error-btn">Retry Connection</button>
         </div>
@@ -613,7 +613,7 @@
             <div class="icon-wrap"><i class="fa-solid fa-gauge-high"></i></div>
             <div class="error-code" style="font-size:48px;">429</div>
           </div>
-          <div class="error-title">Too Many Requests</div>
+          <h1 class="error-title">Too Many Requests</div>
           <div class="rate-badges">
             <span class="badge active">Rate Limited</span>
             <span class="badge">Cooldown Active</span>
@@ -638,7 +638,7 @@
       <div class="component-preview" id="preview-12">
         <div class="error-screen err-location">
           <div class="icon-wrap"><i class="fa-solid fa-location-dot"></i></div>
-          <div class="error-title">Location Access Denied</div>
+          <h1 class="error-title">Location Access Denied</div>
           <div class="coords"><span>LAT</span> ██.████  <span>LNG</span> ██.████</div>
           <div class="error-desc">Your browser has blocked location access. Enable permissions to use location-based features.</div>
           <button class="error-btn">Enable Location</button>
@@ -663,7 +663,7 @@
             <div class="icon-wrap"><i class="fa-solid fa-link-slash"></i></div>
             <div class="error-code" style="font-size:48px; color:#92400e;">410</div>
           </div>
-          <div class="error-title">Link Expired</div>
+          <h1 class="error-title">Link Expired</div>
           <div class="token-row">
             <div class="token-seg"></div>
             <div class="token-seg"></div>
@@ -692,7 +692,7 @@
       <div class="component-preview" id="preview-14">
         <div class="error-screen err-suspended">
           <div class="icon-wrap"><i class="fa-solid fa-ban"></i></div>
-          <div class="error-title">Account Suspended</div>
+          <h1 class="error-title">Account Suspended</div>
           <div class="suspended-bar">
             <span></span><span></span><span></span><span></span><span></span>
           </div>
@@ -716,7 +716,7 @@
       <div class="component-preview" id="preview-15">
         <div class="error-screen err-storage">
           <div class="icon-wrap"><i class="fa-solid fa-hard-drive"></i></div>
-          <div class="error-title">Storage Full</div>
+          <h1 class="error-title">Storage Full</div>
           <div class="storage-meter">
             <div class="storage-fill"></div>
             <span class="storage-pct">100%</span>
@@ -745,7 +745,7 @@
             <span class="region-code">IN</span>
             <i class="fa-solid fa-xmark"></i>
           </div>
-          <div class="error-title">Content Not Available</div>
+          <h1 class="error-title">Content Not Available</div>
           <div class="error-desc">This service is not available in your region due to licensing restrictions.</div>
           <button class="error-btn">Use a VPN</button>
         </div>
@@ -766,7 +766,7 @@
       <div class="component-preview" id="preview-17">
         <div class="error-screen err-construction">
           <div class="icon-wrap"><i class="fa-solid fa-helmet-safety"></i></div>
-          <div class="error-title">We're Building Something<span class="blink-cursor">|</span></div>
+          <h1 class="error-title">We're Building Something<span class="blink-cursor">|</span></div>
           <div class="construction-dots">
             <span></span><span></span><span></span>
           </div>
@@ -791,7 +791,7 @@
         <div class="error-screen err-upload">
           <div class="icon-wrap"><i class="fa-solid fa-cloud-arrow-up"></i></div>
           <div class="upload-x"><i class="fa-solid fa-xmark"></i></div>
-          <div class="error-title">Upload Failed</div>
+          <h1 class="error-title">Upload Failed</div>
           <div class="upload-meta">
             <span class="upload-tag">document.pdf</span>
             <span class="upload-tag err">4.2 MB · Timed out</span>
@@ -972,3 +972,5 @@
 
 </body>
 </html>
+
+<!-- improved by script -->


### PR DESCRIPTION
# Summary
Promoted `.error-title` elements from generic `div` tags to `h1` semantic headings in `error.html`.

Closes #2925 