### PR TITLE
fix: add explicit button types

### DIFF
--- a/button.html
+++ b/button.html
@@ -359,7 +359,7 @@
 
 <!-- ================= NAVBAR ================= -->
 <header class="navbar" id="navbar">
-  <button class="menu-toggle" onclick="toggleSidebar()" aria-label="Toggle Menu">
+  <button type="button"  class="menu-toggle" onclick="toggleSidebar()" aria-label="Toggle Menu">
     <i class="fa-solid fa-bars"></i>
   </button>
 
@@ -376,13 +376,13 @@
   </div>
 
   <div class="nav-right">
-    <button class="nav-btn outline-nav-btn">
+    <button type="button"  class="nav-btn outline-nav-btn">
       <i class="fa-solid fa-plus"></i> Add Component
     </button>
-    <button class="nav-btn primary-nav-btn">
+    <button type="button"  class="nav-btn primary-nav-btn">
       <i class="fa-solid fa-bookmark"></i> My Collection
     </button>
-    <button id="darkModeToggle" class="theme-toggle" title="Toggle Theme">
+    <button type="button"  id="darkModeToggle" class="theme-toggle" title="Toggle Theme">
       <i class="fa-solid fa-moon"></i>
     </button>
   </div>
@@ -409,19 +409,19 @@
     </div>
     <div class="page-hero-right">
       <div class="hero-btn-preview">
-        <button class="gradient-btn preview-float">Gradient</button>
-        <button class="neon-btn preview-float" style="animation-delay:0.2s">Neon</button>
-        <button class="btn-3d preview-float" style="animation-delay:0.4s">3D</button>
+        <button type="button"  class="gradient-btn preview-float">Gradient</button>
+        <button type="button"  class="neon-btn preview-float" style="animation-delay:0.2s">Neon</button>
+        <button type="button"  class="btn-3d preview-float" style="animation-delay:0.4s">3D</button>
       </div>
     </div>
   </div>
 
   <!-- Filter Bar -->
   <div class="filter-bar">
-    <button class="filter-btn active" onclick="filterCards('all', this)">All</button>
-    <button class="filter-btn" onclick="filterCards('style', this)">Style</button>
-    <button class="filter-btn" onclick="filterCards('status', this)">Status</button>
-    <button class="filter-btn" onclick="filterCards('effect', this)">Effects</button>
+    <button type="button"  class="filter-btn active" onclick="filterCards('all', this)">All</button>
+    <button type="button"  class="filter-btn" onclick="filterCards('style', this)">Style</button>
+    <button type="button"  class="filter-btn" onclick="filterCards('status', this)">Status</button>
+    <button type="button"  class="filter-btn" onclick="filterCards('effect', this)">Effects</button>
     <div class="filter-search">
       <i class="fa-solid fa-magnifying-glass"></i>
       <input type="text" placeholder="Filter buttons..." oninput="liveFilter(this.value)" />
@@ -438,14 +438,14 @@
         <span class="card-tag tag-popular">Popular</span>
       </div>
       <div class="card-preview">
-        <button class="gradient-btn">Click Me</button>
+        <button type="button"  class="gradient-btn">Click Me</button>
       </div>
       <p class="card-desc">A vibrant multi-color gradient button with smooth hover transition.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c1', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c1', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c1', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c1', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -470,11 +470,11 @@
       <div class="feature-card">
         <div class="icon">🌈</div>
         <h3>Gradient Button</h3>
-        <button class="gradient-btn">Click Me</button>
+        <button type="button"  class="gradient-btn">Click Me</button>
 
         <div class="actions">
-          <button onclick="toggleCode('c1', this)">View Code</button>
-          <button onclick="copyCode('c1', this)">Copy</button>
+          <button type="button"  onclick="toggleCode('c1', this)">View Code</button>
+          <button type="button"  onclick="copyCode('c1', this)">Copy</button>
         </div>
 
         <pre id="c1" class="code-block">
@@ -500,14 +500,14 @@
         <span class="card-tag tag-essential">Essential</span>
       </div>
       <div class="card-preview">
-        <button class="outline-btn">Click Me</button>
+        <button type="button"  class="outline-btn">Click Me</button>
       </div>
       <p class="card-desc">A clean border-only button — great for secondary actions.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c2', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c2', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c2', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c2', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -533,14 +533,14 @@
         <span class="card-tag tag-trending">Trending</span>
       </div>
       <div class="card-preview dark-preview">
-        <button class="neon-btn">Glow</button>
+        <button type="button"  class="neon-btn">Glow</button>
       </div>
       <p class="card-desc">A glowing neon-style button perfect for dark themed UIs.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c3', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c3', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c3', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c3', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -566,14 +566,14 @@
         <span class="card-tag tag-trending">Trending</span>
       </div>
       <div class="card-preview glass-preview">
-        <button class="glass-btn">Glass</button>
+        <button type="button"  class="glass-btn">Glass</button>
       </div>
       <p class="card-desc">A frosted-glass effect button with backdrop blur.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c4', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c4', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c4', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c4', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -600,14 +600,14 @@
         <span class="card-tag tag-popular">Popular</span>
       </div>
       <div class="card-preview">
-        <button class="shadow-btn">Lift</button>
+        <button type="button"  class="shadow-btn">Lift</button>
       </div>
       <p class="card-desc">A soft shadow button with a satisfying lift on hover.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c5', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c5', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c5', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c5', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -634,14 +634,14 @@
         <span class="card-tag tag-essential">Essential</span>
       </div>
       <div class="card-preview">
-        <button class="rounded-btn">Rounded</button>
+        <button type="button"  class="rounded-btn">Rounded</button>
       </div>
       <p class="card-desc">A fully pill-shaped button — modern and approachable.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c6', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c6', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c6', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c6', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -667,14 +667,14 @@
         <span class="card-tag tag-essential">Essential</span>
       </div>
       <div class="card-preview">
-        <button class="icon-btn"><i class="fa-solid fa-star"></i></button>
+        <button type="button"  class="icon-btn"><i class="fa-solid fa-star"></i></button>
       </div>
       <p class="card-desc">A compact circular icon button for toolbars and action menus.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c7', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c7', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c7', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c7', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -704,14 +704,14 @@
         <span class="card-tag tag-new">Status</span>
       </div>
       <div class="card-preview">
-        <button class="success-btn"><i class="fa-solid fa-check"></i> Success</button>
+        <button type="button"  class="success-btn"><i class="fa-solid fa-check"></i> Success</button>
       </div>
       <p class="card-desc">A green success button — ideal for confirmations and completed actions.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c8', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c8', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c8', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c8', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -737,14 +737,14 @@
         <span class="card-tag tag-danger">Status</span>
       </div>
       <div class="card-preview">
-        <button class="danger-btn"><i class="fa-solid fa-triangle-exclamation"></i> Danger</button>
+        <button type="button"  class="danger-btn"><i class="fa-solid fa-triangle-exclamation"></i> Danger</button>
       </div>
       <p class="card-desc">A red danger/error button for destructive actions.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c9', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c9', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c9', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c9', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -770,14 +770,14 @@
         <span class="card-tag tag-warning">Status</span>
       </div>
       <div class="card-preview">
-        <button class="warning-btn"><i class="fa-solid fa-circle-exclamation"></i> Warning</button>
+        <button type="button"  class="warning-btn"><i class="fa-solid fa-circle-exclamation"></i> Warning</button>
       </div>
       <p class="card-desc">An amber warning button for caution states.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c10', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c10', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c10', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c10', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -803,16 +803,16 @@
         <span class="card-tag tag-popular">Popular</span>
       </div>
       <div class="card-preview">
-        <button class="loading-btn" disabled>
+        <button type="button"  class="loading-btn" disabled>
           <span class="spinner"></span> Loading...
         </button>
       </div>
       <p class="card-desc">A disabled loading state button with an animated spinner.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c11', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c11', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c11', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c11', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
       </div>
@@ -853,17 +853,17 @@
         <span class="card-tag tag-trending">Trending</span>
       </div>
       <div class="card-preview">
-        <button class="btn-3d">3D Effect</button>
+        <button type="button"  class="btn-3d">3D Effect</button>
       </div>
       <p class="card-desc">A tactile 3D push-down button with a solid shadow base.</p>
       <div class="actions">
-        <button class="action-btn view-btn" onclick="toggleCode('c14', this)">
+        <button type="button"  class="action-btn view-btn" onclick="toggleCode('c14', this)">
           <i class="fa-solid fa-code"></i> View Code
         </button>
-        <button class="action-btn copy-btn" onclick="copyCode('c14', this)">
+        <button type="button"  class="action-btn copy-btn" onclick="copyCode('c14', this)">
           <i class="fa-solid fa-copy"></i> Copy
         </button>
-        <button onclick="addToCollection('3D Button')">Add to My Collection</button>
+        <button type="button"  onclick="addToCollection('3D Button')">Add to My Collection</button>
       </div>
       <pre id="c14" class="code-block"><code>&lt;button class="btn-3d"&gt;3D Effect&lt;/button&gt;</code></pre>
     </div>
@@ -878,17 +878,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="gradient-border-btn">Explore</button>
+    <button type="button"  class="gradient-border-btn">Explore</button>
   </div>
 
   <p class="card-desc">A sleek transparent button with animated gradient border.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c15', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c15', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c15', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c15', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -905,17 +905,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="shine-btn">Get Started</button>
+    <button type="button"  class="shine-btn">Get Started</button>
   </div>
 
   <p class="card-desc">Elegant shine animation passing across the button on hover.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c16', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c16', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c16', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c16', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -932,17 +932,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="soft-btn">Soft UI</button>
+    <button type="button"  class="soft-btn">Soft UI</button>
   </div>
 
   <p class="card-desc">Modern neumorphism button with soft inner shadows.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c17', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c17', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c17', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c17', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -959,7 +959,7 @@
   </div>
 
   <div class="card-preview">
-    <button class="slide-btn">
+    <button type="button"  class="slide-btn">
       Continue
       <span><i class="fa-solid fa-arrow-right"></i></span>
     </button>
@@ -968,11 +968,11 @@
   <p class="card-desc">Animated arrow movement for modern CTA interactions.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c18', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c18', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c18', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c18', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -989,17 +989,17 @@
   </div>
 
   <div class="card-preview dark-preview">
-    <button class="premium-btn">Premium</button>
+    <button type="button"  class="premium-btn">Premium</button>
   </div>
 
   <p class="card-desc">Luxury dark UI button with premium glossy finish.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c19', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c19', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c19', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c19', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1017,17 +1017,17 @@
   </div>
 
   <div class="card-preview dark-preview">
-    <button class="cyber-btn">Launch</button>
+    <button type="button"  class="cyber-btn">Launch</button>
   </div>
 
   <p class="card-desc">Futuristic neon cyberpunk-inspired glowing button.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c21', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c21', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c21', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c21', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1063,17 +1063,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="liquid-btn">Liquid</button>
+    <button type="button"  class="liquid-btn">Liquid</button>
   </div>
 
   <p class="card-desc">Smooth liquid hover animation with modern UI feel.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c22', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c22', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c22', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c22', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1116,17 +1116,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="metal-btn">Metal</button>
+    <button type="button"  class="metal-btn">Metal</button>
   </div>
 
   <p class="card-desc">Elegant chrome metallic button with glossy highlights.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c23', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c23', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c23', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c23', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1164,7 +1164,7 @@
   </div>
 
   <div class="card-preview">
-    <button class="expand-btn">
+    <button type="button"  class="expand-btn">
       Hover Me
     </button>
   </div>
@@ -1172,11 +1172,11 @@
   <p class="card-desc">Button smoothly expands width on hover interaction.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c24', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c24', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c24', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c24', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1209,17 +1209,17 @@
   </div>
 
   <div class="card-preview dark-preview">
-    <button class="glass-neon-btn">Future</button>
+    <button type="button"  class="glass-neon-btn">Future</button>
   </div>
 
   <p class="card-desc">Combines glassmorphism and neon glow beautifully.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c25', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c25', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c25', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c25', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1253,7 +1253,7 @@
   </div>
 
   <div class="card-preview">
-    <button class="gradient-glow-btn">
+    <button type="button"  class="gradient-glow-btn">
       Start Now
     </button>
   </div>
@@ -1261,11 +1261,11 @@
   <p class="card-desc">Animated glowing gradient CTA button.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c26', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c26', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c26', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c26', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1308,7 +1308,7 @@
   </div>
 
   <div class="card-preview">
-    <button class="underline-btn">
+    <button type="button"  class="underline-btn">
       Learn More
     </button>
   </div>
@@ -1316,11 +1316,11 @@
   <p class="card-desc">Elegant text button with animated underline effect.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c27', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c27', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c27', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c27', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1328,52 +1328,52 @@
   <div class="container">
 
     <!-- Gradient Button -->
-    <button class="btn gradient-btn">
+    <button type="button"  class="btn gradient-btn">
       Gradient Button
     </button>
 
     <!-- Neon Button -->
-    <button class="btn neon-btn">
+    <button type="button"  class="btn neon-btn">
       Neon Glow
     </button>
 
     <!-- Outline Hover Fill -->
-    <button class="btn outline-btn">
+    <button type="button"  class="btn outline-btn">
       Hover Fill
     </button>
 
     <!-- 3D Button -->
-    <button class="btn three-d-btn">
+    <button type="button"  class="btn three-d-btn">
       3D Button
     </button>
 
     <!-- Glass Button -->
-    <button class="btn glass-btn">
+    <button type="button"  class="btn glass-btn">
       Glass Effect
     </button>
 
     <!-- Slide Arrow Button -->
-    <button class="btn arrow-btn">
+    <button type="button"  class="btn arrow-btn">
       <span>Explore</span>
     </button>
 
     <!-- Pulse Button -->
-    <button class="btn pulse-btn">
+    <button type="button"  class="btn pulse-btn">
       Pulse Button
     </button>
 
     <!-- Dark Mode Toggle -->
-    <button class="btn toggle-btn" id="themeBtn">
+    <button type="button"  class="btn toggle-btn" id="themeBtn">
       🌙 Dark Mode
     </button>
 
     <!-- Shine Effect -->
-    <button class="btn shine-btn">
+    <button type="button"  class="btn shine-btn">
       Shine Button
     </button>
 
     <!-- Floating Button -->
-    <button class="btn floating-btn">
+    <button type="button"  class="btn floating-btn">
       +
     </button>
 
@@ -1414,7 +1414,7 @@
   </div>
 
   <div class="card-preview">
-    <button class="floating-btn">
+    <button type="button"  class="floating-btn">
       Floating
     </button>
   </div>
@@ -1422,11 +1422,11 @@
   <p class="card-desc">Soft floating animation with subtle movement.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c28', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c28', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c28', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c28', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1462,17 +1462,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="ripple-btn">Ripple</button>
+    <button type="button"  class="ripple-btn">Ripple</button>
   </div>
 
   <p class="card-desc">Material-inspired ripple hover interaction.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c20', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c20', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c20', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c20', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1490,17 +1490,17 @@
   </div>
 
   <div class="card-preview dark-preview">
-    <button class="neon-glow-btn">Glow Flow</button>
+    <button type="button"  class="neon-glow-btn">Glow Flow</button>
   </div>
 
   <p class="card-desc">RGB neon glow animation with floating back-shadow on hover.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c29', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c29', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c29', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c29', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1516,17 +1516,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="magnetic-hover-btn">Pull Me</button>
+    <button type="button"  class="magnetic-hover-btn">Pull Me</button>
   </div>
 
   <p class="card-desc">Sleek tactile button that responds dynamically to cursor proximity.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c30', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c30', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c30', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c30', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1542,17 +1542,17 @@
   </div>
 
   <div class="card-preview glass-preview">
-    <button class="glassmorphism-btn">Frosted Glass</button>
+    <button type="button"  class="glassmorphism-btn">Frosted Glass</button>
   </div>
 
   <p class="card-desc">Stunning glassmorphic frosted button with custom borders and hover shine sweep.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c31', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c31', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c31', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c31', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1568,17 +1568,17 @@
   </div>
 
   <div class="card-preview">
-    <button class="ripple-effect-btn">Click Me</button>
+    <button type="button"  class="ripple-effect-btn">Click Me</button>
   </div>
 
   <p class="card-desc">Material-style dynamic ripple circle originating from the click coordinate.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c32', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c32', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c32', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c32', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1594,7 +1594,7 @@
   </div>
 
   <div class="card-preview">
-    <button class="loading-state-btn" onclick="triggerLoadingState(this)">
+    <button type="button"  class="loading-state-btn" onclick="triggerLoadingState(this)">
       <span class="spinner-icon"></span>
       <span class="btn-text">Submit Order</span>
     </button>
@@ -1603,11 +1603,11 @@
   <p class="card-desc">Beautiful button with interactive spinner loading state and complete success feedback.</p>
 
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c33', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c33', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
 
-    <button class="action-btn copy-btn" onclick="copyCode('c33', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c33', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1625,14 +1625,14 @@
     <span class="card-tag tag-trending">Animated</span>
   </div>
   <div class="card-preview dark-preview">
-    <button class="aurora-btn">Explore</button>
+    <button type="button"  class="aurora-btn">Explore</button>
   </div>
   <p class="card-desc">A flowing multicolor gradient button with a luminous hover lift.</p>
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c34', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c34', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
-    <button class="action-btn copy-btn" onclick="copyCode('c34', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c34', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1646,14 +1646,14 @@
     <span class="card-tag tag-new">Playful</span>
   </div>
   <div class="card-preview">
-    <button class="jelly-btn">Bounce</button>
+    <button type="button"  class="jelly-btn">Bounce</button>
   </div>
   <p class="card-desc">A soft playful button that squashes and springs on hover.</p>
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c35', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c35', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
-    <button class="action-btn copy-btn" onclick="copyCode('c35', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c35', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1667,14 +1667,14 @@
     <span class="card-tag tag-essential">Clean</span>
   </div>
   <div class="card-preview">
-    <button class="outline-fill-btn">Discover</button>
+    <button type="button"  class="outline-fill-btn">Discover</button>
   </div>
   <p class="card-desc">A crisp outlined button that fills from left to right on hover.</p>
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c36', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c36', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
-    <button class="action-btn copy-btn" onclick="copyCode('c36', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c36', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1688,17 +1688,17 @@
     <span class="card-tag tag-popular">Utility</span>
   </div>
   <div class="card-preview">
-    <button class="split-icon-btn">
+    <button type="button"  class="split-icon-btn">
       <span>Download</span>
       <i class="fa-solid fa-download"></i>
     </button>
   </div>
   <p class="card-desc">A practical action button with a separated icon segment.</p>
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c37', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c37', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
-    <button class="action-btn copy-btn" onclick="copyCode('c37', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c37', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1715,14 +1715,14 @@
     <span class="card-tag tag-trending">Elegant</span>
   </div>
   <div class="card-preview">
-    <button class="border-draw-btn">Contact Us</button>
+    <button type="button"  class="border-draw-btn">Contact Us</button>
   </div>
   <p class="card-desc">A refined button whose border traces itself into view on hover.</p>
   <div class="actions">
-    <button class="action-btn view-btn" onclick="toggleCode('c38', this)">
+    <button type="button"  class="action-btn view-btn" onclick="toggleCode('c38', this)">
       <i class="fa-solid fa-code"></i> View Code
     </button>
-    <button class="action-btn copy-btn" onclick="copyCode('c38', this)">
+    <button type="button"  class="action-btn copy-btn" onclick="copyCode('c38', this)">
       <i class="fa-solid fa-copy"></i> Copy
     </button>
   </div>
@@ -1734,7 +1734,7 @@
 </main>
 
 <!-- ===== SCROLL TO TOP ===== -->
-<button id="scrollTopBtn" onclick="scrollToTop()" title="Back to top">
+<button type="button"  id="scrollTopBtn" onclick="scrollToTop()" title="Back to top">
   <i class="fa-solid fa-chevron-up"></i>
 </button>
 


### PR DESCRIPTION
Closes #2939 

# Summary
Added `type="button"` to `<button>` elements within `button.html` that lacked them. This prevents unintended behavior where buttons act as submit inputs by default.
