### PR TITLE
feat: replace emojis with icons in blog page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -87,7 +87,7 @@
 <section class="trending-section">
 
   <div class="section-heading">
-    <span class="section-badge">🔥 Trending Now</span>
+    <span class="section-badge"><i class="fa-solid fa-fire"></i> Trending Now</span>
     <h2>Most Popular This Week</h2>
   </div>
 
@@ -563,7 +563,7 @@
       <!-- Sidebar -->
       <aside class="blog-sidebar">
         <div class="bs-card bs-newsletter">
-          <div class="bs-newsletter-icon">✉</div>
+          <div class="bs-newsletter-icon"><i class="fa-solid fa-envelope"></i></div>
           <h3>Stay in the loop</h3>
           <p>Get new articles and component drops delivered to your inbox every week.</p>
           <form class="bs-newsletter-form" onsubmit="return false;">
@@ -574,7 +574,7 @@
         </div>
 
         <div class="bs-card">
-          <div class="bs-heading"><span>▢</span> Popular Posts</div>
+          <div class="bs-heading"><span><i class="fa-solid fa-square"></i></span> Popular Posts</div>
           <div class="bs-popular-list">
             <a href="#" class="bs-popular-item">
               <div class="bs-popular-num">01</div>
@@ -601,7 +601,7 @@
         </div>
 
         <div class="bs-card">
-          <div class="bs-heading"><span>▢</span> Browse Topics</div>
+          <div class="bs-heading"><span><i class="fa-solid fa-square"></i></span> Browse Topics</div>
           <div class="bs-topics">
             <button type="button" onclick="filterPosts('tutorial', null)" class="bs-topic-tag">Tutorials</button>
             <button type="button" onclick="filterPosts('tips', null)" class="bs-topic-tag">Tips & Tricks</button>
@@ -613,7 +613,7 @@
         </div>
 
         <div class="bs-card">
-          <div class="bs-heading"><span>▢</span> Authors</div>
+          <div class="bs-heading"><span><i class="fa-solid fa-square"></i></span> Authors</div>
           <div class="bs-authors">
             <div class="bs-author-item">
               <div class="blog-avatar blog-avatar-purple">CN</div>
@@ -712,7 +712,7 @@
     </div>
 
     <div class="footer-bottom">
-      <p>© 2026 UIverse. Made with ❤ for developers worldwide.</p>
+      <p>© 2026 UIverse. Made with <i class="fa-solid fa-heart" style="color: #ff4757;"></i> for developers worldwide.</p>
     </div>
   </footer>
 


### PR DESCRIPTION
# Related Issue
Closes #2943 

# Summary
Standardizes the iconography on the `blog.html` page by replacing native system emojis and text symbols with FontAwesome icons, improving cross-platform visual consistency.

# Changes Made
* Replaced `🔥` with `fa-fire` in the trending section.
* Replaced `✉` with `fa-envelope` in the newsletter card.
* Replaced the `▢` symbol with `fa-square` across the sidebar widgets.
* Replaced the native `❤` emoji in the footer with a styled `fa-heart`.

# Testing
* [x] Tested locally
* [x] No unrelated changes included
