### PR TITLE
fix: add role attributes to badges and replace emoji with icon

### DIFF
--- a/badges.html
+++ b/badges.html
@@ -387,7 +387,7 @@ MAIN
   <section class="hero-section">
 
     <div class="hero-badge">
-      ✦ UIverse Badge Collection
+      <i class="fa-solid fa-sparkles"></i> UIverse Badge Collection
     </div>
 
     <h1>
@@ -824,15 +824,15 @@ BADGE CARD — VIP BADGE
 
       <div class="badge-preview">
 
-        <span class="badge success-badge">
+        <span class="badge success-badge" role="status">
           Approved
         </span>
 
-        <span class="badge warning-badge">
+        <span class="badge warning-badge" role="status">
           Pending
         </span>
 
-        <span class="badge danger-badge">
+        <span class="badge danger-badge" role="status">
           Rejected
         </span>
 


### PR DESCRIPTION
# Related Issue
Closes #2945 

# Summary
Enhances the accessibility of the status badges on the `badges.html` page by applying the `role="status"` attribute, ensuring they are properly communicated by screen readers. 

# Changes Made
* Added `role="status"` to `.success-badge`, `.warning-badge`, and `.danger-badge`.
* Replaced the text character `✦` in the hero badge with `<i class="fa-solid fa-sparkles"></i>`.

# Testing
* [x] Checked ARIA roles
* [x] Code follows project style
