### PR TITLE
Feat (404): Add Custom 404.html Page to improve Error page UX

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - Page Not Found | UI-verse</title>
+    <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/tabler-icons.min.css">
+
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: "DM Sans", system-ui, sans-serif;
+        background: #f5f5f3;
+        color: #1a1a1a;
+        text-align: center;
+        padding: 2rem;
+        overflow: hidden;
+        position: relative;
+      }
+
+      body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background-image: radial-gradient(
+          circle,
+          rgba(235, 104, 53, 0.13) 1px,
+          transparent 1px
+        );
+        background-size: 28px 28px;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      body::after {
+        content: "404";
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-family: "Syne", sans-serif;
+        font-size: clamp(180px, 40vw, 340px);
+        font-weight: 800;
+        color: rgba(235, 104, 53, 0.045);
+        letter-spacing: -16px;
+        pointer-events: none;
+        -webkit-user-select: none;
+        user-select: none;
+        z-index: 0;
+        white-space: nowrap;
+      }
+
+      .container {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        max-width: 480px;
+      }
+
+      .floater {
+        position: fixed;
+        background: #fff;
+        border: 1px solid #e8e8e6;
+        border-radius: 10px;
+        padding: 8px 13px;
+        font-size: 12px;
+        color: #aaa;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        pointer-events: none;
+        animation: bob linear infinite;
+        z-index: 0;
+      }
+      .floater i {
+        font-size: 14px;
+        color: #eb6835;
+        opacity: 0.7;
+      }
+      .f1 {
+        top: 12%;
+        left: 4%;
+        animation-duration: 6s;
+        animation-delay: 0s;
+      }
+      .f2 {
+        top: 16%;
+        right: 5%;
+        animation-duration: 7s;
+        animation-delay: -2s;
+      }
+      .f3 {
+        bottom: 18%;
+        left: 6%;
+        animation-duration: 8s;
+        animation-delay: -1s;
+      }
+      .f4 {
+        bottom: 14%;
+        right: 4%;
+        animation-duration: 6.5s;
+        animation-delay: -3s;
+      }
+      .f5 {
+        top: 48%;
+        left: 2%;
+        animation-duration: 9s;
+        animation-delay: -4s;
+      }
+
+      @keyframes bob {
+        0%,
+        100% {
+          transform: translateY(0px);
+        }
+        50% {
+          transform: translateY(-10px);
+        }
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #fff;
+        border: 1px solid #e2e2e0;
+        border-radius: 999px;
+        padding: 5px 14px;
+        font-size: 13px;
+        color: #888;
+        letter-spacing: 0.04em;
+        margin-bottom: 1.5rem;
+      }
+      .badge i {
+        font-size: 14px;
+        color: #eb6835;
+      }
+
+      .big-404 {
+        font-family: "Syne", sans-serif;
+        font-size: clamp(72px, 20vw, 120px);
+        font-weight: 800;
+        line-height: 1;
+        letter-spacing: -4px;
+        margin-bottom: 1.25rem;
+        animation: pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+      }
+      @keyframes pop {
+        from {
+          transform: scale(0.8);
+          opacity: 0;
+        }
+        to {
+          transform: scale(1);
+          opacity: 1;
+        }
+      }
+      .big-404 .accent {
+        color: #eb6835;
+      }
+
+      h1 {
+        font-family: "Syne", sans-serif;
+        font-size: 24px;
+        font-weight: 700;
+        color: #561800;
+        margin-bottom: 0.6rem;
+      }
+
+      p {
+        font-size: 15px;
+        color: #666;
+        line-height: 1.7;
+        margin-bottom: 2rem;
+        max-width: 340px;
+      }
+
+      .floating-cards {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        justify-content: center;
+        margin-bottom: 2rem;
+      }
+      .mini-card {
+        background: #fff;
+        border: 1px solid #e8e8e6;
+        border-radius: 12px;
+        padding: 10px 14px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        color: #888;
+        animation: bob linear infinite;
+      }
+      .mini-card:nth-child(1) {
+        animation-duration: 5s;
+        animation-delay: 0s;
+      }
+      .mini-card:nth-child(2) {
+        animation-duration: 6.5s;
+        animation-delay: -1.5s;
+      }
+      .mini-card:nth-child(3) {
+        animation-duration: 7s;
+        animation-delay: -3s;
+      }
+      .mini-card i {
+        font-size: 15px;
+        color: #eb6835;
+      }
+
+      .btn-group {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+      .btn-primary {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #eb6835;
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 10px 22px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        text-decoration: none;
+        transition: opacity 0.15s;
+      }
+      .btn-primary:hover {
+        opacity: 0.85;
+      }
+      .btn-ghost {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #fff;
+        color: #555;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 10px 22px;
+        font-size: 14px;
+        cursor: pointer;
+        text-decoration: none;
+        transition: background 0.15s;
+      }
+      .btn-ghost:hover {
+        background: #f0f0ee;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- floating file chips -->
+    <div class="floater f1"><i class="ti ti-layout-grid"></i> button.html</div>
+    <div class="floater f2"><i class="ti ti-palette"></i> theme.css</div>
+    <div class="floater f3"><i class="ti ti-box"></i> modal.html</div>
+    <div class="floater f4"><i class="ti ti-code"></i> card.html</div>
+    <div class="floater f5"><i class="ti ti-photo"></i> avatar.svg</div>
+
+    <div class="container">
+      <div class="badge">
+        <i class="ti ti-compass-off"></i>
+        lost in UIverse
+      </div>
+
+      <div class="big-404">4<span class="accent">0</span>4</div>
+
+      <h1>Page not found</h1>
+      <p>
+        Looks like this component got deleted. The page you're looking for
+        doesn't exist or may have been moved.
+      </p>
+
+      <div class="floating-cards">
+        <div class="mini-card">
+          <i class="ti ti-layout-grid"></i> components
+        </div>
+        <div class="mini-card"><i class="ti ti-palette"></i> themes</div>
+        <div class="mini-card"><i class="ti ti-box"></i> templates</div>
+      </div>
+
+      <div class="btn-group">
+        <a class="btn-primary" href="/"
+          ><i class="ti ti-home"></i> Back to Home</a
+        >
+        <a class="btn-ghost" href="/components"
+          ><i class="ti ti-layout-grid"></i> Browse Components</a
+        >
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue
Closes #2886 

## Summary
Adds a custom `404.html` page to replace the host's generic error page. The page matches UIverse's branding and gives users a clear path back into the site.

## Changes Made
- Added `404.html` to the repository root
- Includes a dot-grid background pattern, ghost watermark, and floating animated file chips for visual depth
- CTA buttons linking back to `/` (home) and `/components`
- Passes `html-validate` with no errors

## Testing
Served the project locally using `npx serve .` and navigated to a non-existent route (e.g. `http://localhost:3000/random`). The custom `404.html` page rendered correctly instead of the default server error page.

## Screenshots
### Desktop

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/b3bd6c2f-d384-4fd1-b6d7-dbe7b356731f" />

### Mobile

<img width="431" height="959" alt="image" src="https://github.com/user-attachments/assets/aa990586-bd7e-44b9-8a5c-4f245ef0045c" />


## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)