### PR TITLE
Compare selection should persist across page refreshes

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -33,7 +33,7 @@
     cachedOverlayGrid = document.getElementById(OVERLAY_GRID_ID);
   }
 
-  function loadSelectionFromStorage(storage = sessionStorage) {
+  function loadSelectionFromStorage(storage = localStorage) {
     try {
       const raw = storage.getItem(STORAGE_KEY);
       if (!raw) return [];
@@ -45,7 +45,7 @@
     }
   }
 
-  function persistSelectionToStorage(selectedIds, storage = sessionStorage) {
+  function persistSelectionToStorage(selectedIds, storage = localStorage) {
     try {
       storage.setItem(STORAGE_KEY, JSON.stringify(selectedIds));
     } catch (e) {


### PR DESCRIPTION
Updated compare persistence in compare.js and compare.js: both storage helpers now default to `localStorage` instead of `sessionStorage`, so compare selections survive refreshes and tab closes while keeping the existing versioned key `uiVerseCompare.selectedComponentIds.v1`.

Validation passed with no errors in the file.


closes #2764