### PR TITLE
[Bug] Compare IDs can change when card order changes

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -1,6 +1,6 @@
 (function () {
   const MAX_COMPARE = 3;
-  const STORAGE_KEY = 'uiVerseCompare.selectedComponentIds.v1';
+  const STORAGE_KEY = 'uiVerseCompare.selectedComponentIds.v2';
 
   const CARD_SELECTOR = '.component-card';
   const CARD_ID_ATTR = 'data-compare-id';
@@ -131,6 +131,42 @@
     return `${name}::${cat}::${contentSignature}`;
   }
 
+  function normalizeCompareSignaturePart(value) {
+    return String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+  }
+
+  function hashCompareSignature(signature) {
+    let hash = 2166136261;
+
+    for (let index = 0; index < signature.length; index += 1) {
+      hash ^= signature.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+
+    return (hash >>> 0).toString(36);
+  }
+
+  function buildCompareIdSignature(cardEl) {
+    if (!cardEl) return '';
+
+    const stableAttributes = ['data-component-id', 'data-name', 'data-title', 'data-cat', 'data-id', 'id'];
+    const attributeParts = stableAttributes
+      .map((attr) => normalizeCompareSignaturePart(cardEl.getAttribute(attr)))
+      .filter(Boolean);
+
+    if (attributeParts.length) {
+      return attributeParts.join('::');
+    }
+
+    const preview = cardEl.querySelector('.card-preview');
+    const previewSignature = preview ? preview.outerHTML : cardEl.outerHTML;
+    const textSignature = normalizeCompareSignaturePart(cardEl.textContent || '');
+
+    return [cardEl.tagName, textSignature.slice(0, 200), normalizeCompareSignaturePart(previewSignature).slice(0, 4000)]
+      .filter(Boolean)
+      .join('::');
+  }
+
   function ensureCompareCell(compareId, cardEl, onActivate) {
     if (!compareId || !cardEl) return null;
 
@@ -185,22 +221,20 @@
 
   function ensureCompareId(cardEl) {
     if (!cardEl || !(cardEl instanceof HTMLElement)) return null;
-    if (cardEl.getAttribute(CARD_ID_ATTR)) return cardEl.getAttribute(CARD_ID_ATTR);
+    const existingId = cardEl.getAttribute(CARD_ID_ATTR);
+    if (existingId) return existingId;
 
-    // Prefer stable-ish identifier
-    const name = (cardEl.getAttribute('data-name') || '').trim();
-    const cat = (cardEl.getAttribute('data-cat') || '').trim();
-
-    // Fallback: index within grid
-    const all = cachedCards.length ? cachedCards : getCardElements();
-    const idx = all.indexOf(cardEl);
-
-    const metaKey = [name, cat].filter(Boolean).join('__');
-    const raw = metaKey || `card__${idx}`;
-    const safe = raw.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
-
-    // Keep metadata-backed IDs stable across DOM re-renders.
-    const id = metaKey ? safe : `${safe}__${idx}`;
+    const signature = buildCompareIdSignature(cardEl);
+    const primaryLabel = normalizeCompareSignaturePart(
+      cardEl.getAttribute('data-component-id') ||
+      cardEl.getAttribute('data-name') ||
+      cardEl.getAttribute('data-title') ||
+      cardEl.getAttribute('data-id') ||
+      cardEl.getAttribute('id') ||
+      'card'
+    );
+    const safeLabel = primaryLabel.replace(/[^a-z0-9_-]/g, '_').slice(0, 40) || 'card';
+    const id = `cmp_${safeLabel}_${hashCompareSignature(signature)}`;
 
     cardEl.setAttribute(CARD_ID_ATTR, id);
     return id;

--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -33,7 +33,7 @@
     cachedOverlayGrid = document.getElementById(OVERLAY_GRID_ID);
   }
 
-  function loadSelectionFromStorage(storage = sessionStorage) {
+  function loadSelectionFromStorage(storage = localStorage) {
     try {
       const raw = storage.getItem(STORAGE_KEY);
       if (!raw) return [];
@@ -45,7 +45,7 @@
     }
   }
 
-  function persistSelectionToStorage(selectedIds, storage = sessionStorage) {
+  function persistSelectionToStorage(selectedIds, storage = localStorage) {
     try {
       storage.setItem(STORAGE_KEY, JSON.stringify(selectedIds));
     } catch (e) {


### PR DESCRIPTION
Updated compare.js so compare IDs no longer depend on card order. `ensureCompareId()` now prefers stable attributes like `data-component-id`, `data-name`, `data-title`, `data-cat`, `data-id`, or `id`, and otherwise derives a deterministic hash from the card’s semantic content instead of using the grid index. I also bumped the persisted storage key to `uiVerseCompare.selectedComponentIds.v2` so old index-based selections do not conflict with the new ID scheme.

Validation passed with no errors in the file.

closes  #2765