### PR TITLE
[Bug] Potential memory/cached-cell growth during dynamic card filtering

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -205,18 +205,21 @@
     });
 
     for (const [compareId, entry] of cachedCompareCells.entries()) {
-      if (nextIds.includes(compareId)) continue;
-      if (entry && entry.cell && entry.cell.parentElement === gridEl) {
-        gridEl.removeChild(entry.cell);
-      }
-    }
+      const cell = entry && entry.cell;
+      const cellInGrid = !!cell && gridEl.contains(cell);
 
-    cachedCompareCells.forEach((entry, compareId) => {
-      if (nextIds.includes(compareId)) return;
-      if (entry && entry.cell && !entry.cell.isConnected) {
+      if (nextIds.includes(compareId)) {
+        continue;
+      }
+
+      if (cellInGrid) {
+        gridEl.removeChild(cell);
+      }
+
+      if (!cellInGrid || !cell.isConnected) {
         cachedCompareCells.delete(compareId);
       }
-    });
+    }
   }
 
   function ensureCompareId(cardEl) {


### PR DESCRIPTION
Updated the overlay cache cleanup in js/features/compare.js so stale compare cells are deleted whenever they are no longer inside the current overlay grid, not just when they become disconnected from the DOM. That closes the gap where cached entries could linger during heavy dynamic card changes.

Validation passed for the touched file: no errors were reported.


closes #2769