### PR TITLE
Tutorial completion may be incorrectly set when all remaining steps are missing

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -205,18 +205,21 @@
     });
 
     for (const [compareId, entry] of cachedCompareCells.entries()) {
-      if (nextIds.includes(compareId)) continue;
-      if (entry && entry.cell && entry.cell.parentElement === gridEl) {
-        gridEl.removeChild(entry.cell);
-      }
-    }
+      const cell = entry && entry.cell;
+      const cellInGrid = !!cell && gridEl.contains(cell);
 
-    cachedCompareCells.forEach((entry, compareId) => {
-      if (nextIds.includes(compareId)) return;
-      if (entry && entry.cell && !entry.cell.isConnected) {
+      if (nextIds.includes(compareId)) {
+        continue;
+      }
+
+      if (cellInGrid) {
+        gridEl.removeChild(cell);
+      }
+
+      if (!cellInGrid || !cell.isConnected) {
         cachedCompareCells.delete(compareId);
       }
-    });
+    }
   }
 
   function ensureCompareId(cardEl) {

--- a/js/features/tutorial-mode.js
+++ b/js/features/tutorial-mode.js
@@ -10,6 +10,7 @@ const TutorialMode = {
     resolvedSteps: [],
     activeSteps: [],
     missingSteps: [],
+    renderedStepCount: 0,
     currentIndex: 0,
     active: false,
     pageKey: 'global',
@@ -160,6 +161,7 @@ const TutorialMode = {
 
     this._state.currentIndex = 0;
     this._state.active = true;
+    this._state.renderedStepCount = 0;
 
     this._ensureUI();
     this._bindUIEvents();
@@ -313,6 +315,7 @@ const TutorialMode = {
       const el = step.targetEl && step.targetEl.isConnected ? step.targetEl : null;
       if (el) {
         this._state.currentIndex = idx;
+        this._state.renderedStepCount += 1;
         this._showStep(step, el);
         return;
       }
@@ -320,7 +323,7 @@ const TutorialMode = {
     }
 
     // If we reach here, all remaining steps have missing selectors
-    this.complete();
+    this.complete(false, this._state.renderedStepCount > 0);
   },
 
   _showStep(step, el) {
@@ -459,9 +462,12 @@ const TutorialMode = {
     this.complete(true);
   },
 
-  complete(skip = false) {
+  complete(skip = false, shouldMarkCompleted = true) {
     this._state.active = false;
-    this._setCompleted();
+
+    if (shouldMarkCompleted) {
+      this._setCompleted();
+    }
 
     if (this._state.refreshHandler) {
       window.removeEventListener('scroll', this._state.refreshHandler);


### PR DESCRIPTION
Adjusted js/features/tutorial-mode.js so the tutorial only writes its completed flag after at least one step has actually rendered. If `_render()` now finds no usable active steps, it closes without marking completion, which avoids falsely finishing a tutorial that never showed anything.

Validation passed on the touched file: no errors found.

closes #2770