### PR TITLE
doc-fix: incorrect repo url in documentation

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -379,10 +379,10 @@ if (localStorage.getItem('theme') === 'dark') {
 
           <div class="gl-steps">
             <div class="gl-step">
-              <div class="gl-step-num gl-step-github"><i class="fa-brands fa-github"></i></div>
+              <div class="gl-step-num">1</div>
               <div class="gl-step-body">
                 <h4>Fork the repository</h4>
-                <p>Go to <a class="gl-link" href="https://github.com/chinmay1126/UI-Verse" target="_blank">github.com/chinmay1126/UI-Verse</a> and click "Fork" to create your own copy.</p>
+                <p>Go to <a class="gl-link" href="https://github.com/Tushar-sonawane06/UI-Verse" target="_blank">github.com/Tushar-sonawane06/UI-Verse</a> and click "Fork" to create your own copy.</p>
               </div>
             </div>
             <div class="gl-step">


### PR DESCRIPTION
## Related Issue
Closes #3080 

## Summary
Fixed the repo URL in the documentation page.

## Changes Made
- changed the URL to `https://github.com/Tushar-sonawane06/UI-Verse`
-  changed the URL test to `github.com/Tushar-sonawane06/UI-Verse`


## Screenshots
<img width="1595" height="799" alt="image" src="https://github.com/user-attachments/assets/b95b035f-1290-4360-9884-672d6b3f7ab7" />

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)