### PR TITLE
Feat(colors): Add CSS-only tooltips to trending color swatch buttons

### DIFF
--- a/color.html
+++ b/color.html
@@ -480,8 +480,8 @@
         <div class="color-swatch" style="background:#8b5cf6;">
           <span class="swatch-badge">Popular</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#8b5cf6', this)" title="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(139,92,246)', this)" title="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#8b5cf6', this)" title="Copy HEX" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(139,92,246)', this)" title="Copy RGB" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -495,8 +495,8 @@
         <div class="color-swatch" style="background:#06b6d4;">
           <span class="swatch-badge">New</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#06b6d4', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(6,182,212)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#06b6d4', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(6,182,212)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -510,8 +510,8 @@
         <div class="color-swatch" style="background:#f43f5e;">
           <span class="swatch-badge">Hot</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#f43f5e', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(244,63,94)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#f43f5e', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(244,63,94)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -525,8 +525,8 @@
         <div class="color-swatch" style="background:#eb6835;">
           <span class="swatch-badge">Brand</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#eb6835', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(235,104,53)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#eb6835', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(235,104,53)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -540,8 +540,8 @@
         <div class="color-swatch" style="background:#00b894;">
           <span class="swatch-badge">Fresh</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#00b894', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(0,184,148)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#00b894', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(0,184,148)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -555,8 +555,8 @@
         <div class="color-swatch" style="background:#6c5ce7;">
           <span class="swatch-badge">Classic</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#6c5ce7', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(108,92,231)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#6c5ce7', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(108,92,231)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -570,8 +570,8 @@
         <div class="color-swatch" style="background:#fdcb6e;">
           <span class="swatch-badge">Warm</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#fdcb6e', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(253,203,110)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#fdcb6e', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(253,203,110)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -585,8 +585,8 @@
         <div class="color-swatch" style="background:#0984e3;">
           <span class="swatch-badge">Clean</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#0984e3', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(9,132,227)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#0984e3', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(9,132,227)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -600,8 +600,8 @@
         <div class="color-swatch" style="background:#ff7a3d;">
           <span class="swatch-badge">Warm</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#ff7a3d', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(255,122,61)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#ff7a3d', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(255,122,61)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -615,8 +615,8 @@
         <div class="color-swatch" style="background:#00b894;">
           <span class="swatch-badge">Fresh</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#00b894', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(0,184,148)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#00b894', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(0,184,148)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -630,8 +630,8 @@
         <div class="color-swatch" style="background:#f5c542;">
           <span class="swatch-badge">Premium</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#f5c542', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(245,197,66)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#f5c542', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(245,197,66)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -645,8 +645,8 @@
         <div class="color-swatch" style="background:#3f37c9;">
           <span class="swatch-badge">Bold</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#3f37c9', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(63,55,201)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#3f37c9', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(63,55,201)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">
@@ -660,8 +660,8 @@
         <div class="color-swatch" style="background:#14b8a6;">
           <span class="swatch-badge">Calm</span>
           <div class="swatch-actions">
-            <button onclick="copyText('#14b8a6', this)"><i class="fa-solid fa-hashtag"></i></button>
-            <button onclick="copyText('rgb(20,184,166)', this)"><i class="fa-solid fa-circle-half-stroke"></i></button>
+            <button type="button" onclick="copyText('#14b8a6', this)" aria-label="Copy HEX"><i class="fa-solid fa-hashtag"></i></button>
+            <button type="button" onclick="copyText('rgb(20,184,166)', this)" aria-label="Copy RGB"><i class="fa-solid fa-circle-half-stroke"></i></button>
           </div>
         </div>
         <div class="color-info">

--- a/colors.css
+++ b/colors.css
@@ -497,6 +497,7 @@
   border-radius: 8px;
   border: none;
   background: rgba(255,255,255,0.25);
+  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   color: #fff;
   font-size: 13px;
@@ -509,6 +510,74 @@
 
 .swatch-actions button:hover {
   background: rgba(255,255,255,0.45);
+}
+
+.swatch-actions button {
+  position: relative;
+}
+
+.swatch-actions button::after {
+  content: attr(aria-label);
+  position: absolute;
+  bottom: calc(100% + 7px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: #111111a8;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-body);
+  white-space: nowrap;
+  padding: 4px 10px;
+  border-radius: 6px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.swatch-actions button::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 3px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  border: 5px solid transparent;
+  border-top-color: transparent;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.swatch-actions button:hover::after,
+.swatch-actions button:hover::before {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+body.dark-mode .swatch-actions button::after {
+  background: #f0f0f0a8;
+  color: #111;
+}
+
+body.dark-mode .swatch-actions button::before {
+  border-top-color: transparent;
+}
+
+.swatch-actions button:last-child::after {
+  left: auto;
+  right: 0;
+  transform: translateY(4px);
+}
+
+.swatch-actions button:last-child::before {
+  left: auto;
+  right: 12px;
+  transform: translateY(4px);
+}
+
+.swatch-actions button:last-child:hover::after,
+.swatch-actions button:last-child:hover::before {
+  transform: translateY(0);
 }
 
 .color-info {


### PR DESCRIPTION
## Related Issue
Closes #3082

## Summary
Adds hover tooltips to the HEX and RGB copy buttons on trending color cards using pure CSS, no JavaScript.

The icon-only buttons (hashtag and half-circle) weren't self-explanatory. Users had no way to know which button copied which value without guessing.

## Changes Made
- Used `::after` pseudo-element with `content: attr(aria-label)` so tooltip text comes from the existing accessibility label
- Semi-transparent dark background (`#111111a8`) with a subtle slide-in transition
- Right-anchored tooltip on the last button to prevent clipping at the card edge (caused by `overflow: hidden` on `.color-swatch`)
- Dark mode handled via `body.dark-mode` overrides

## Screenshots
| Mode | Copy Hex | Copy RGB |
| ------ | ----------- | ----------- |
| Light | <img width="395" height="413" alt="image" src="https://github.com/user-attachments/assets/3fb37ca4-b09e-46ae-8f77-e941dcb09595" /> | <img width="415" height="396" alt="image" src="https://github.com/user-attachments/assets/47ba9c8a-7fbc-4d01-ac22-a0c010ec94c8" /> |
| Dark | <img width="402" height="413" alt="image" src="https://github.com/user-attachments/assets/a354f670-462d-487a-a481-883d4638dc6c" /> | <img width="431" height="418" alt="image" src="https://github.com/user-attachments/assets/ce8129ab-f9ac-4b52-8db8-a314249a75d6" /> |



## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [ ] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)