### PR TITLE
fix: resolve unclosed HTML comments on calendar components page

### DIFF
--- a/calendarcomponent.html
+++ b/calendarcomponent.html
@@ -449,7 +449,7 @@
   </section>
 
     <!-- =========================================
-     PROJECT MANAGEMENT CALENDAR
+     PROJECT MANAGEMENT CALENDAR -->
 <div class="component-card">
 
   <div class="card-top">
@@ -504,7 +504,7 @@
 </div>
 
 <!-- =========================================
-     MEETING ROOM BOOKING
+     MEETING ROOM BOOKING -->
 <div class="component-card">
 
   <div class="card-top">
@@ -548,7 +548,7 @@
 </div>
 
 <!-- =========================================
-     DARK EVENT SCHEDULER
+     DARK EVENT SCHEDULER -->
 <div class="component-card">
 
   <div class="card-top">
@@ -609,7 +609,7 @@
 </div>
 
 <!-- =========================================
-     MINIMAL DAY PLANNER
+     MINIMAL DAY PLANNER -->
 <div class="component-card">
 
   <div class="card-top">
@@ -664,7 +664,7 @@
 </div>
 
 <!-- =========================================
-     AI SMART ASSISTANT
+     AI SMART ASSISTANT -->
 <div class="component-card">
 
   <div class="card-top">
@@ -712,7 +712,7 @@
 </div>
 
 <!-- =========================================
-     DEADLINE TRACKER
+     DEADLINE TRACKER -->
 <div class="component-card">
 
   <div class="card-top">


### PR DESCRIPTION
Closes #3147 

Removes trailing open comment markers inside `calendarcomponent.html` to restore missing UI calendar components.
