### PR TITLE
fix: enclose boxes 9 to 18 within the bento-container grid

### DIFF
--- a/bent-grid.html
+++ b/bent-grid.html
@@ -600,7 +600,7 @@
       </button>
     </div>
 
-  </section>
+
   <!-- =========================
      FINANCE ANALYTICS CARD
 ========================= -->
@@ -839,6 +839,7 @@
 
   </div>
 </div>
+  </section>
   <!-- FOOTER -->
 <footer class="footer">
   <div class="footer-container">


### PR DESCRIPTION
Closes #3151 

Encloses grid box templates properly inside container elements on `bent-grid.html` to align grid flow.
