### PR TITLE
fix: load script.js correctly using script tag in carousel.html

### DIFF
--- a/carousel.html
+++ b/carousel.html
@@ -26,7 +26,7 @@
   <!-- UIverse Modular CSS Architecture -->
   <!-- <link rel="stylesheet" href="css/main.css"> -->
   <link rel="stylesheet" href="shared-sidebar.css">
-  <link rel="JavaScript" href="script.js">
+  <script src="script.js" defer></script>
 </head>
 <body>
   


### PR DESCRIPTION
Closes #3168 

Corrects the path to script files to fix carousel transition events.
