### PR TITLE
fix: implement message wrapping and scrollable height constraints in chatui.html

### DIFF
--- a/chatui.html
+++ b/chatui.html
@@ -42,6 +42,18 @@
   <link rel="stylesheet" href="shared-page.css">
   <link rel="stylesheet" href="cards.css">
   <link rel="stylesheet" href="playground.css">
+  <style>
+    /* Message wrapping & dynamic height constraints */
+    .bubble {
+      word-break: break-word;
+      overflow-wrap: break-word;
+    }
+    .chat-window {
+      max-height: 480px;
+      overflow-y: auto;
+      padding-right: 8px;
+    }
+  </style>
 
 </head>
 


### PR DESCRIPTION
Closes #3172 

Adds responsive height constraints and text wrapping parameters on message bubbles.
