### PR TITLE
fix: add responsive horizontal scroll support for comparison tables

### DIFF
--- a/comparison-tables.html
+++ b/comparison-tables.html
@@ -40,7 +40,15 @@
     rel="stylesheet"
     href="shared-sidebar.css"
   />
-
+  <style>
+    /* Responsive horizontal scrolling container for tables on small viewports */
+    .table-wrapper {
+      width: 100% !important;
+      overflow-x: auto !important;
+      -webkit-overflow-scrolling: touch;
+      margin-bottom: 2rem;
+    }
+  </style>
 </head>
 
 <body>


### PR DESCRIPTION
Closes #3182 

Wraps table tags inside responsive scrollable classes to preserve column layouts on mobile devices.
