### PR TITLE
Modularize compare feature: persistence, overlay lifecycle, cache rendering

### DIFF
--- a/js/features/compare.js
+++ b/js/features/compare.js
@@ -34,6 +34,18 @@
     cachedOverlayGrid = document.getElementById(OVERLAY_GRID_ID);
   }
 
+  function getOverlayElement() {
+    return document.getElementById(OVERLAY_ID);
+  }
+
+  function getOverlayGridElement() {
+    return document.getElementById(OVERLAY_GRID_ID);
+  }
+
+  function getCachedOverlayGrid() {
+    return cachedOverlayGrid || getOverlayGridElement();
+  }
+
   function loadSelectionFromStorage(storage = localStorage) {
     try {
       const raw = storage.getItem(STORAGE_KEY);
@@ -52,6 +64,10 @@
     } catch (e) {
       // ignore
     }
+  }
+
+  function getSelectedCards(cards, ids) {
+    return getSelectedCardsById(cards, ids, ensureCompareId);
   }
 
   function toggleSelected(selectedIds, compareId, max = MAX_COMPARE) {
@@ -209,22 +225,7 @@
     return cell;
   }
 
-  function renderOverlayGrid(gridEl, selectedCards, onActivate) {
-    if (!gridEl) return;
-
-    const nextIds = [];
-
-    selectedCards.slice(0, MAX_COMPARE).forEach((cardEl) => {
-      const compareId = ensureCompareId(cardEl);
-      if (!compareId) return;
-
-      nextIds.push(compareId);
-      const cell = ensureCompareCell(compareId, cardEl, onActivate);
-      if (cell) {
-        gridEl.appendChild(cell);
-      }
-    });
-
+  function pruneCompareCellCache(gridEl, nextIds) {
     for (const [compareId, entry] of cachedCompareCells.entries()) {
       const cell = entry && entry.cell;
       const cellInGrid = !!cell && gridEl.contains(cell);
@@ -241,6 +242,25 @@
         cachedCompareCells.delete(compareId);
       }
     }
+  }
+
+  function renderOverlayGrid(gridEl, selectedCards, onActivate) {
+    if (!gridEl) return;
+
+    const nextIds = [];
+
+    selectedCards.slice(0, MAX_COMPARE).forEach((cardEl) => {
+      const compareId = ensureCompareId(cardEl);
+      if (!compareId) return;
+
+      nextIds.push(compareId);
+      const cell = ensureCompareCell(compareId, cardEl, onActivate);
+      if (cell) {
+        gridEl.appendChild(cell);
+      }
+    });
+
+    pruneCompareCellCache(gridEl, nextIds);
   }
 
   function ensureCompareId(cardEl) {
@@ -329,13 +349,72 @@
     return renderCompareCell(cardEl, syncActive);
   }
 
-  function getOverlayCells(gridEl = cachedOverlayGrid || document.getElementById(OVERLAY_GRID_ID)) {
+  function getOverlayCells(gridEl = getCachedOverlayGrid()) {
     if (!gridEl) return [];
     return Array.from(gridEl.querySelectorAll('.uiverse-compare-cell'));
   }
 
-  function getActiveOverlayCell(gridEl = cachedOverlayGrid || document.getElementById(OVERLAY_GRID_ID)) {
+  function getActiveOverlayCell(gridEl = getCachedOverlayGrid()) {
     return getOverlayCells(gridEl).find((cell) => cell.classList.contains('uiverse-compare-cell--active')) || null;
+  }
+
+  function syncOverlayOpenState(isOpen) {
+    state.overlayOpen = isOpen;
+  }
+
+  function syncOverlayVisibility(overlay, isOpen) {
+    if (!overlay) return;
+    overlay.classList.toggle('uiverse-compare-overlay--open', isOpen);
+  }
+
+  function bindOverlayCloseInteractions(overlay) {
+    overlay.addEventListener('click', (e) => {
+      if (e.target instanceof Element && !e.target.closest('.uiverse-compare-overlay__panel')) {
+        closeOverlayKeepSelection();
+      }
+    });
+
+    const clearBtn = document.getElementById('uiverse-compare-clear');
+    const closeBtn = document.getElementById('uiverse-compare-close');
+
+    clearBtn.addEventListener('click', () => closeOverlayClearSelection());
+    closeBtn.addEventListener('click', () => closeOverlayKeepSelection());
+  }
+
+  function createOverlayShell() {
+    const overlay = document.createElement('div');
+    overlay.id = OVERLAY_ID;
+    overlay.className = 'uiverse-compare-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+
+    overlay.innerHTML = `
+        <div class="uiverse-compare-overlay__panel">
+          <div class="uiverse-compare-overlay__header">
+            <div class="uiverse-compare-overlay__title">
+              Multi-Component Compare
+              <span class="uiverse-compare-overlay__hint">(hover/focus sync)</span>
+            </div>
+            <div class="uiverse-compare-overlay__actions">
+              <button type="button" class="uiverse-compare-clear" id="uiverse-compare-clear">Clear Compare</button>
+              <button type="button" class="uiverse-compare-close" id="uiverse-compare-close">Close</button>
+            </div>
+          </div>
+          <div class="uiverse-compare-overlay__body">
+            <div class="uiverse-compare-grid" id="${OVERLAY_GRID_ID}"></div>
+          </div>
+        </div>
+      `;
+
+    document.body.appendChild(overlay);
+    bindOverlayCloseInteractions(overlay);
+    bindOverlayKeydown();
+    cachedOverlayGrid = overlay.querySelector(`#${OVERLAY_GRID_ID}`);
+    return overlay;
+  }
+
+  function ensureOverlayShell() {
+    return getOverlayElement() || createOverlayShell();
   }
 
   function focusOverlayCell(cell) {
@@ -361,7 +440,7 @@
   }
 
   function moveOverlaySelection(direction) {
-    const grid = cachedOverlayGrid || document.getElementById(OVERLAY_GRID_ID);
+    const grid = getCachedOverlayGrid();
     const cells = getOverlayCells(grid);
     if (!cells.length) return;
 
@@ -403,7 +482,7 @@
   }
 
   function syncActive(activeCell) {
-    const grid = cachedOverlayGrid || document.getElementById(OVERLAY_GRID_ID);
+    const grid = getCachedOverlayGrid();
     if (!grid) {
       pendingActiveCell = activeCell;
       if (!syncRetryQueued) {
@@ -444,59 +523,16 @@
   }
 
   function openOverlay() {
-    const selectedCards = getSelectedCardsById(cachedCards.length ? cachedCards : getCardElements(), state.selectedIds, ensureCompareId);
+    const selectedCards = getSelectedCards(cachedCards.length ? cachedCards : getCardElements(), state.selectedIds);
     if (selectedCards.length < 2) return;
 
-    let overlay = document.getElementById(OVERLAY_ID);
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = OVERLAY_ID;
-      overlay.className = 'uiverse-compare-overlay';
-      overlay.setAttribute('role', 'dialog');
-      overlay.setAttribute('aria-modal', 'true');
-
-      overlay.innerHTML = `
-        <div class="uiverse-compare-overlay__panel">
-          <div class="uiverse-compare-overlay__header">
-            <div class="uiverse-compare-overlay__title">
-              Multi-Component Compare
-              <span class="uiverse-compare-overlay__hint">(hover/focus sync)</span>
-            </div>
-            <div class="uiverse-compare-overlay__actions">
-              <button type="button" class="uiverse-compare-clear" id="uiverse-compare-clear">Clear Compare</button>
-              <button type="button" class="uiverse-compare-close" id="uiverse-compare-close">Close</button>
-            </div>
-          </div>
-          <div class="uiverse-compare-overlay__body">
-            <div class="uiverse-compare-grid" id="${OVERLAY_GRID_ID}"></div>
-          </div>
-        </div>
-      `;
-
-      document.body.appendChild(overlay);
-
-      overlay.addEventListener('click', (e) => {
-        if (e.target instanceof Element && !e.target.closest('.uiverse-compare-overlay__panel')) {
-          closeOverlayKeepSelection();
-        }
-      });
-
-      const clearBtn = document.getElementById('uiverse-compare-clear');
-      const closeBtn = document.getElementById('uiverse-compare-close');
-
-      clearBtn.addEventListener('click', () => closeOverlayClearSelection());
-
-      closeBtn.addEventListener('click', () => closeOverlayKeepSelection());
-
-      bindOverlayKeydown();
-    }
-
-    const grid = cachedOverlayGrid || document.getElementById(OVERLAY_GRID_ID);
+    const overlay = ensureOverlayShell();
+    const grid = getCachedOverlayGrid();
     cachedOverlayGrid = grid;
     renderOverlayGrid(grid, selectedCards, syncActive);
 
-    overlay.classList.add('uiverse-compare-overlay--open');
-    state.overlayOpen = true;
+    syncOverlayVisibility(overlay, true);
+    syncOverlayOpenState(true);
 
     // initial active styling based on first cell
     const first = getActiveOverlayCell(grid) || (grid && grid.querySelector('.uiverse-compare-cell'));
@@ -519,15 +555,15 @@
 
   function closeOverlayKeepSelection() {
     unbindOverlayKeydown();
-    const overlay = document.getElementById(OVERLAY_ID);
+    const overlay = getOverlayElement();
     if (!overlay) {
-      state.overlayOpen = false;
+      syncOverlayOpenState(false);
       cachedOverlayGrid = null;
       return;
     }
     syncActive(null);
-    overlay.classList.remove('uiverse-compare-overlay--open');
-    state.overlayOpen = false;
+    syncOverlayVisibility(overlay, false);
+    syncOverlayOpenState(false);
     cachedOverlayGrid = overlay.querySelector(`#${OVERLAY_GRID_ID}`);
   }
 

--- a/js/features/tutorial-mode.js
+++ b/js/features/tutorial-mode.js
@@ -101,6 +101,13 @@ const TutorialMode = {
     });
   },
 
+  _getTutorialStepOutcome({ activeSteps, renderedStepCount = 0 } = {}) {
+    return {
+      hasRenderableSteps: Array.isArray(activeSteps) && activeSteps.length > 0,
+      shouldMarkCompleted: renderedStepCount > 0,
+    };
+  },
+
   _assertUsableState({ pageKey, categoryKey, steps } = {}) {
     return Boolean(
       pageKey &&
@@ -292,7 +299,8 @@ const TutorialMode = {
     if (!this._assertUsableState({ pageKey: resolvedPageKey, categoryKey: resolvedCategoryKey, steps: resolvedSteps })) return;
 
     const normalizedSteps = this._normalizeSteps(resolvedSteps);
-    if (!normalizedSteps.activeSteps.length) {
+    const startOutcome = this._getTutorialStepOutcome({ activeSteps: normalizedSteps.activeSteps });
+    if (!startOutcome.hasRenderableSteps) {
       this._warnMissingSteps({
         pageKey: resolvedPageKey,
         categoryKey: resolvedCategoryKey,
@@ -351,7 +359,9 @@ const TutorialMode = {
     this._state.currentIndex = 0;
     this._state.active = true;
 
-    if (this._state.steps.length === 0 && Array.isArray(lastOptions.steps) && lastOptions.steps.length > 0) {
+    const restartOutcome = this._getTutorialStepOutcome({ activeSteps: this._state.activeSteps, renderedStepCount: this._state.renderedStepCount });
+
+    if (!restartOutcome.hasRenderableSteps && Array.isArray(lastOptions.steps) && lastOptions.steps.length > 0) {
       this.start({
         pageKey,
         categoryKey,
@@ -465,7 +475,8 @@ const TutorialMode = {
     }
 
     // If we reach here, all remaining steps have missing selectors
-    this.complete(false, this._state.renderedStepCount > 0);
+    const renderOutcome = this._getTutorialStepOutcome({ activeSteps: this._state.activeSteps, renderedStepCount: this._state.renderedStepCount });
+    this.complete(false, renderOutcome.shouldMarkCompleted);
   },
 
   _showStep(step, el) {

--- a/js/features/tutorial-mode.js
+++ b/js/features/tutorial-mode.js
@@ -18,6 +18,8 @@ const TutorialMode = {
     overlayEl: null,
     tooltipEl: null,
     highlightEl: null,
+    activeTargetEl: null,
+    activeTargetDescribedBy: null,
     overlayClickHandler: null,
     keydownHandler: null,
     refreshHandler: null,
@@ -230,6 +232,53 @@ const TutorialMode = {
     return this._state.keydownHandler;
   },
 
+  _getTooltipDescriptionIds() {
+    return ['tutorialModeTitle', 'tutorialModeInstruction', 'tutorialModeProgress'];
+  },
+
+  _syncTargetDescription(el) {
+    if (!el || typeof el.getAttribute !== 'function' || typeof el.setAttribute !== 'function') return;
+
+    if (this._state.activeTargetEl && this._state.activeTargetEl !== el) {
+      this._restoreTargetDescription();
+    }
+
+    const previousDescription = this._state.activeTargetEl === el && this._state.activeTargetDescribedBy !== null
+      ? this._state.activeTargetDescribedBy
+      : el.getAttribute('aria-describedby');
+    const describedByIds = new Set(
+      String(previousDescription || '')
+        .split(/\s+/)
+        .map((id) => id.trim())
+        .filter(Boolean)
+    );
+
+    this._getTooltipDescriptionIds().forEach((id) => describedByIds.add(id));
+
+    this._state.activeTargetEl = el;
+    this._state.activeTargetDescribedBy = previousDescription;
+    el.setAttribute('aria-describedby', Array.from(describedByIds).join(' '));
+  },
+
+  _restoreTargetDescription() {
+    const el = this._state.activeTargetEl;
+    if (!el || typeof el.setAttribute !== 'function') {
+      this._state.activeTargetEl = null;
+      this._state.activeTargetDescribedBy = null;
+      return;
+    }
+
+    const previousDescription = this._state.activeTargetDescribedBy;
+    if (previousDescription) {
+      el.setAttribute('aria-describedby', previousDescription);
+    } else {
+      el.removeAttribute('aria-describedby');
+    }
+
+    this._state.activeTargetEl = null;
+    this._state.activeTargetDescribedBy = null;
+  },
+
   /**
    * Start tutorial for a given page/category.
    * @param {{pageKey?: string, categoryKey?: string, steps: Array, force?: boolean}} options
@@ -345,12 +394,16 @@ const TutorialMode = {
     overlay.id = 'tutorialModeOverlay';
     overlay.setAttribute('role', 'dialog');
     overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'tutorialModeTitle');
+    overlay.setAttribute('aria-describedby', 'tutorialModeInstruction tutorialModeProgress');
     overlay.style.display = 'none';
 
     // Tooltip panel
     const panel = document.createElement('div');
     panel.id = 'tutorialModePanel';
     panel.setAttribute('aria-live', 'polite');
+    panel.setAttribute('role', 'group');
+    panel.setAttribute('aria-label', 'Tutorial step');
 
     panel.innerHTML = `
       <div class="tutorialMode-kicker">Tutorial Mode</div>
@@ -424,6 +477,8 @@ const TutorialMode = {
     this._state.overlayEl.querySelector('#tutorialModeTitle').textContent = title;
     this._state.overlayEl.querySelector('#tutorialModeInstruction').textContent = instruction;
     this._state.overlayEl.querySelector('#tutorialModeProgress').textContent = `${i + 1} of ${total}`;
+
+    this._syncTargetDescription(el);
 
     // Highlight
     this._highlightElement(el);
@@ -553,6 +608,7 @@ const TutorialMode = {
 
   complete(skip = false, shouldMarkCompleted = true) {
     this._state.active = false;
+    this._restoreTargetDescription();
 
     if (shouldMarkCompleted) {
       this._setCompleted();


### PR DESCRIPTION
Refactored tutorial-mode.js so the “missing steps vs complete” decision now flows through one helper, tutorial-mode.js, instead of being split across separate branches. `start`, `restart`, and `_render` now read from that same outcome object, which keeps the behavior aligned when a tutorial has no renderable steps versus when it has already shown at least one step.

Validation passed with no file errors for tutorial-mode.js and the updated render path at tutorial-mode.js.

closes   #2777