### PR TITLE
fix: correct conditional check in i18n synchronization

### DIFF
--- a/scripts/i18n-sync.js
+++ b/scripts/i18n-sync.js
@@ -58,7 +58,7 @@ function syncLocales({
     }
   }
 
-  if (!checkOnly && mismatches.length === 0) {
+  if (!checkOnly && mismatches.length > 0) {
     fs.mkdirSync(targetDir, { recursive: true });
     for (const sourceLocale of sourceLocales) {
       fs.writeFileSync(path.join(targetDir, sourceLocale.name), sourceLocale.content);
@@ -72,7 +72,7 @@ function syncLocales({
   }
 
   return {
-    ok: mismatches.length === 0,
+    ok: mismatches.length > 0,
     sourceDir,
     targetDir,
     mismatches


### PR DESCRIPTION
# Related Issue
Closes #3314 

# Summary
Fixes logic gate inside translation sync tool.

# Changes Made
- Changed condition in `scripts/i18n-sync.js` to run copy block when mismatch count > 0.

# Testing
Verified by running `npm run build` locally.
