### PR TITLE
fix: add missing buildDependencies function in metadata script

### DIFF
--- a/scripts/component-metadata.js
+++ b/scripts/component-metadata.js
@@ -28,6 +28,30 @@ function isSemver(version){
   return SEMVER_RE.test(String(version || '').trim());
 }
 
+function buildDependencies(componentId, componentPath){
+  const id = String(componentId || path.basename(componentPath || 'component', '.html')).toLowerCase();
+  const localStyle = id === 'index' ? 'home.css' : (id === 'color' ? 'colors.css' : `${id}.css`);
+
+  if (id === 'index') {
+    return {
+      styles: ['style.css', 'home.css'],
+      scripts: ['script.js', 'js/features/theme.js', 'js/features/search.js', 'js/features/command-palette.js', 'js/features/accessibility.js']
+    };
+  }
+
+  if (id === 'settings') {
+    return {
+      styles: ['style.css', 'css/main.css'],
+      scripts: ['script.js', 'js/features/theme.js', 'js/features/sidebar.js', 'js/features/search.js', 'js/features/code-tools.js', 'js/features/sandbox.js', 'js/features/accessibility.js', 'js/features/toast.js', 'js/features/popup.js']
+    };
+  }
+
+  return {
+    styles: ['style.css', 'css/main.css', localStyle],
+    scripts: ['script.js', 'js/features/theme.js', 'js/features/accessibility.js', 'js/features/code-tools.js', 'js/features/sandbox.js']
+  };
+}
+
 function today(){ return new Date().toISOString().split('T')[0]; }
 
 function normalizeChangelogText(text) {


### PR DESCRIPTION
# Related Issue
Closes #3316 

# Summary
Restores the missing dependency builder function inside the metadata generator.

# Changes Made
- Added `buildDependencies` in `scripts/component-metadata.js`.

# Testing
Ran `npm run components:version:generate` to verify completion.
