### PR TITLE
feat(task-manager): persistent storage, tooltips, and UX polish

### DIFF
--- a/taskmanager/task.css
+++ b/taskmanager/task.css
@@ -55,6 +55,18 @@ body{
   background:#1d4ed8;
 }
 
+#clearAllBtn {
+  padding:14px 22px;
+  border:none;
+  background:#ef4444;
+  color:#fff;
+  border-radius:10px;
+  cursor:pointer;
+  transition:0.3s;
+}
+
+#clearAllBtn:hover{ background:#dc2626; }
+
 .task-input button:disabled{
   background:#93c5fd;
   cursor:not-allowed;

--- a/taskmanager/task.css
+++ b/taskmanager/task.css
@@ -55,6 +55,11 @@ body{
   background:#1d4ed8;
 }
 
+.task-input button:disabled{
+  background:#93c5fd;
+  cursor:not-allowed;
+}
+
 .task-sections{
   display:grid;
   grid-template-columns:1fr 1fr;
@@ -66,6 +71,17 @@ body{
   padding:20px;
   border-radius:16px;
   box-shadow:0 4px 12px rgba(0,0,0,0.1);
+  border-top: 3px solid transparent;
+}
+
+#pendingTasks:empty::after,
+#completedTasks:empty::after{
+  content: "No tasks here";
+  display: block;
+  text-align: center;
+  color: #aaa;
+  font-size: 14px;
+  padding: 24px 0;
 }
 
 .task-column h2{
@@ -82,11 +98,19 @@ body{
   justify-content:space-between;
   align-items:center;
   animation:fadeIn 0.3s ease;
+  transition:transform 0.15s, box-shadow 0.15s;
 }
+
+.task-card:hover{
+  transform:translateY(-2px);
+  box-shadow:0 4px 10px rgba(0,0,0,0.08);
+}
+
 
 .task-buttons{
   display:flex;
   gap:10px;
+  position:relative;
 }
 
 .complete-btn,
@@ -96,6 +120,30 @@ body{
   border-radius:8px;
   color:#fff;
   cursor:pointer;
+  position:relative;
+}
+
+.complete-btn::after,
+.delete-btn::after{
+  content:attr(aria-label);
+  position:absolute;
+  bottom:calc(100% + 6px);
+  left:50%;
+  transform:translateX(-50%);
+  background:#1e293b;
+  color:#fff;
+  font-size:12px;
+  white-space:nowrap;
+  padding:4px 8px;
+  border-radius:6px;
+  pointer-events:none;
+  opacity:0;
+  transition:opacity 0.15s;
+}
+
+.complete-btn:hover::after,
+.delete-btn:hover::after{
+  opacity:1;
 }
 
 .complete-btn{
@@ -105,6 +153,9 @@ body{
 .delete-btn{
   background:#ef4444;
 }
+
+.complete-btn:hover { background:#16a34a; }
+.delete-btn:hover   { background:#dc2626; }
 
 @keyframes fadeIn{
   from{
@@ -123,4 +174,8 @@ body{
   .task-sections{
     grid-template-columns:1fr;
   }
+  
+  #pendingTasks ~ h2,
+  .task-column:first-child{ border-top-color:#facc15; }
+  .task-column:last-child { border-top-color:#22c55e; }
 }

--- a/taskmanager/task.html
+++ b/taskmanager/task.html
@@ -21,7 +21,9 @@
 
       <input type="text" id="taskInput" placeholder="Enter task" data-a11y-remediation="label-needed">
 
-      <button id="addTaskBtn">Add Task</button>
+      <button type="button" id="addTaskBtn">Add Task</button>
+
+      <button type="button" id="clearAllBtn" style="padding:14px 22px;border:none;background:#ef4444;color:#fff;border-radius:10px;cursor:pointer;transition:0.3s;">Clear All</button>
 
     </div>
 

--- a/taskmanager/task.html
+++ b/taskmanager/task.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Task Manager UI</title>
   <link rel="stylesheet" href="task.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"/>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -14,7 +15,7 @@
 
   <div class="task-manager">
 
-    <h1>Task Manager</h1>
+    <h1><i class="fas fa-tasks"></i> Task Manager</h1>
 
     <div class="task-input">
 
@@ -26,20 +27,14 @@
 
     <div class="task-sections">
 
-      <div class="task-column">
-
-        <h2>Pending</h2>
-
+      <div class="task-column" style="border-top-color:#facc15;">
+        <h2><i class="fa-regular fa-clock"></i> Pending</h2>
         <div class="task-list" id="pendingTasks"></div>
-
       </div>
 
-      <div class="task-column">
-
-        <h2>Completed</h2>
-
+      <div class="task-column" style="border-top-color:#22c55e;">
+        <h2><i class="fa-regular fa-check-circle"></i> Completed</h2>
         <div class="task-list" id="completedTasks"></div>
-
       </div>
 
     </div>
@@ -47,6 +42,6 @@
   </div>
 
   <script src="task.js"></script>
-      <script src="../dist/shared.js"></script>
+  <script src="../dist/shared.js"></script>
 </body>
 </html>

--- a/taskmanager/task.js
+++ b/taskmanager/task.js
@@ -1,6 +1,5 @@
 const taskInput = document.getElementById("taskInput");
 const addTaskBtn = document.getElementById("addTaskBtn");
-
 const pendingTasks = document.getElementById("pendingTasks");
 const completedTasks = document.getElementById("completedTasks");
 
@@ -11,48 +10,74 @@ taskInput.addEventListener("input", () => {
 });
 addTaskBtn.disabled = true;
 
-function addTask(){
+// Confirms and clears all tasks from both lists and storage
+document.getElementById("clearAllBtn").addEventListener("click", () => {
+  if(!confirm("Clear all tasks?")) return;
+  pendingTasks.innerHTML = "";
+  completedTasks.innerHTML = "";
+  localStorage.removeItem("tasks");
+});
 
-  const taskText = taskInput.value.trim();
+// serializes both lists to localStorage on every add, complete, or delete
+function saveTasks(){
+  const pending = [...pendingTasks.querySelectorAll(".task-card span")].map(s => s.textContent);
+  const completed = [...completedTasks.querySelectorAll(".task-card span")].map(s => s.textContent);
+  localStorage.setItem("tasks", JSON.stringify({ pending, completed }));
+}
 
-  if(taskText === ""){
-    return;
-  }
-
+function createTaskCard(taskText, isCompleted = false){
   const taskCard = document.createElement("div");
-
   taskCard.classList.add("task-card");
 
-  const span = document.createElement('span');
+  const span = document.createElement("span");
   span.textContent = taskText;
 
-  const buttonsDiv = document.createElement('div');
-  buttonsDiv.className = 'task-buttons';
+  const buttonsDiv = document.createElement("div");
+  buttonsDiv.className = "task-buttons";
 
-  const completeBtn = document.createElement('button');
-  completeBtn.className = 'complete-btn';
-  completeBtn.setAttribute('aria-label', 'Mark as completed');
-  completeBtn.innerHTML = '<i class="fa-solid fa-check"></i>';
-
-  const deleteBtn = document.createElement('button');
-  deleteBtn.className = 'delete-btn';
-  deleteBtn.setAttribute('aria-label', 'Delete task');
+  const deleteBtn = document.createElement("button");
+  deleteBtn.className = "delete-btn";
+  deleteBtn.setAttribute("aria-label", "Delete task");
+  deleteBtn.setAttribute("data-tooltip", "Delete task");
   deleteBtn.innerHTML = '<i class="fa-solid fa-trash"></i>';
+  deleteBtn.addEventListener("click", () => { taskCard.remove(); saveTasks(); });
 
-  buttonsDiv.appendChild(completeBtn);
+  if(!isCompleted){
+    const completeBtn = document.createElement("button");
+    completeBtn.className = "complete-btn";
+    completeBtn.setAttribute("aria-label", "Mark task as completed");
+    completeBtn.setAttribute("data-tooltip", "Mark as completed");
+    completeBtn.innerHTML = '<i class="fa-solid fa-check"></i>';
+    completeBtn.addEventListener("click", () => {
+      completeBtn.remove();
+      completedTasks.appendChild(taskCard);
+      saveTasks();
+    });
+    buttonsDiv.appendChild(completeBtn);
+  }
+
   buttonsDiv.appendChild(deleteBtn);
-
-  completeBtn.addEventListener('click', () => {
-    completeBtn.remove();
-    completedTasks.appendChild(taskCard);
-  });
-
-  deleteBtn.addEventListener('click', () => taskCard.remove());
-
   taskCard.appendChild(span);
   taskCard.appendChild(buttonsDiv);
-
-  pendingTasks.appendChild(taskCard);
-
-  taskInput.value = "";
+  return taskCard;
 }
+
+function addTask(){
+  const taskText = taskInput.value.trim();
+  if(taskText === "") return;
+  pendingTasks.appendChild(createTaskCard(taskText, false));
+  taskInput.value = "";
+  addTaskBtn.disabled = true;
+  saveTasks();
+}
+
+// runs on page load and rebuilds the cards from storage
+function loadTasks(){
+  const saved = localStorage.getItem("tasks");
+  if(!saved) return;
+  const { pending, completed } = JSON.parse(saved);
+  pending.forEach(t => pendingTasks.appendChild(createTaskCard(t, false)));
+  completed.forEach(t => completedTasks.appendChild(createTaskCard(t, true)));
+}
+
+loadTasks();

--- a/taskmanager/task.js
+++ b/taskmanager/task.js
@@ -5,6 +5,11 @@ const pendingTasks = document.getElementById("pendingTasks");
 const completedTasks = document.getElementById("completedTasks");
 
 addTaskBtn.addEventListener("click", addTask);
+taskInput.addEventListener("keydown", e => { if(e.key === "Enter") addTask(); });
+taskInput.addEventListener("input", () => {
+  addTaskBtn.disabled = taskInput.value.trim() === "";
+});
+addTaskBtn.disabled = true;
 
 function addTask(){
 
@@ -26,11 +31,13 @@ function addTask(){
 
   const completeBtn = document.createElement('button');
   completeBtn.className = 'complete-btn';
-  completeBtn.textContent = 'Done';
+  completeBtn.setAttribute('aria-label', 'Mark as completed');
+  completeBtn.innerHTML = '<i class="fa-solid fa-check"></i>';
 
   const deleteBtn = document.createElement('button');
   deleteBtn.className = 'delete-btn';
-  deleteBtn.textContent = 'Delete';
+  deleteBtn.setAttribute('aria-label', 'Delete task');
+  deleteBtn.innerHTML = '<i class="fa-solid fa-trash"></i>';
 
   buttonsDiv.appendChild(completeBtn);
   buttonsDiv.appendChild(deleteBtn);


### PR DESCRIPTION
## Related Issue
Closes #3419

## Summary
Improves the Task Manager UI with localStorage persistence, button tooltips, empty state hints, and minor interaction polish. Tasks now survive page refresh and are cleared cleanly via a confirm-gated button.

## Changes Made
- Added `localStorage` read/write so pending and completed tasks persist across sessions
- Added a Clear All button with a confirm dialog to wipe both lists and storage
- Added CSS `::after` tooltips on the Complete and Delete buttons via `aria-label`
- Disabled the Add button when input is empty; Enter key also submits
- Task cards lift on hover with a subtle shadow transition
- Column headers get a colored top-accent border (yellow = pending, green = completed)
- Empty state message shown when a list has no tasks

## Testing
1. Add a few tasks, refresh the page — tasks should reappear in their respective columns
2. Complete a task, refresh — it should appear in the Completed column without the complete button
3. Delete a task — confirm it's removed from storage (check `localStorage` in DevTools)
4. Click Clear All — a confirm dialog appears; on confirm, both lists are emptied, and storage is cleared
5. Hover over the Complete/Delete buttons — the tooltip appears centered above each

## Screenshots
| Before | After |
| ------- | ------ |
| <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/911f2f30-804e-4b5d-8a7b-963f7a0c3900" /> | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/78272299-78c2-4de1-a8bf-3881510e819d" /> |

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
- [x] If component behavior/UI changed, metadata version and changelog were updated (`npm run components:version:check`)