### PR TITLE
ci: resolve eslint global variable warnings for build and test tools

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,5 +12,37 @@
     "no-unused-vars": ["warn"],
     "no-console": ["off"],
     "no-undef": ["error"]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "scripts/**/*.js",
+        "tests/**/*.js",
+        "*.js",
+        "*.config.js"
+      ],
+      "env": {
+        "node": true
+      },
+      "parserOptions": {
+        "sourceType": "script"
+      }
+    },
+    {
+      "files": [
+        "scripts/**/*.mjs",
+        "*.config.js",
+        "rollup.config.js",
+        "vite.config.js",
+        "retro-pixel.js",
+        "sw.js"
+      ],
+      "env": {
+        "node": true
+      },
+      "parserOptions": {
+        "sourceType": "module"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
# Related Issue
Closes #3518 

# Summary
Fixes the ESLint parser environment rules by introducing targeted overrides for build tools, configurations, and test runners.

# Changes Made
- Added `overrides` config to `.eslintrc.json`.
- Configured CommonJS files (scripts, tests, root files) to run in a `node` environment.
- Configured ES Module config files (Rollup, Vite, Service Worker, etc.) to use `module` sourceType.

# Testing
Validated locally:
```bash
npx eslint scripts/generate-contrib-template.js rollup.config.js
