### PR TITLE
feat: contributor impact dashboard , per-contributor stats, adoption metrics, and activity timeline

### DIFF
--- a/contributor-dashboard.html
+++ b/contributor-dashboard.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contributor Impact Dashboard — UIverse</title>
+
+  <!-- Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Sans:wght@300;400;500;700&display=swap" rel="stylesheet">
+
+  <!-- Icons -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+  <!-- Shared styles -->
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="home.css">
+  <link rel="stylesheet" href="shared-sidebar.css">
+
+  <style>
+    /* ── Layout ── */
+    .cb-main {
+      padding: 32px 40px 80px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .cb-page-header {
+      margin-bottom: 32px;
+    }
+
+    .cb-page-header h1 {
+      font-family: 'Syne', sans-serif;
+      font-size: clamp(26px, 4vw, 40px);
+      font-weight: 800;
+      letter-spacing: -0.5px;
+      margin-bottom: 8px;
+    }
+
+    .cb-page-header h1 span {
+      background: linear-gradient(135deg, #eb6835, #7b61ff);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .cb-page-header p {
+      color: var(--text-secondary, #64748b);
+      font-size: 15px;
+    }
+
+    /* ── Toolbar ── */
+    .cb-toolbar {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-bottom: 24px;
+    }
+
+    .cb-search {
+      flex: 1;
+      min-width: 200px;
+      padding: 10px 14px;
+      border: 1.5px solid var(--border, #e2e8f0);
+      border-radius: 10px;
+      font-family: 'DM Sans', sans-serif;
+      font-size: 14px;
+      background: var(--surface, #fff);
+      color: var(--text-primary, #1a2332);
+      outline: none;
+      transition: border-color 0.2s;
+    }
+
+    .cb-search:focus { border-color: #eb6835; }
+
+    .cb-sort {
+      padding: 10px 14px;
+      border: 1.5px solid var(--border, #e2e8f0);
+      border-radius: 10px;
+      font-family: 'DM Sans', sans-serif;
+      font-size: 14px;
+      background: var(--surface, #fff);
+      color: var(--text-primary, #1a2332);
+      outline: none;
+      cursor: pointer;
+    }
+
+    /* ── Split layout ── */
+    .cb-split {
+      display: grid;
+      grid-template-columns: 320px 1fr;
+      gap: 24px;
+      align-items: start;
+    }
+
+    @media (max-width: 860px) {
+      .cb-split { grid-template-columns: 1fr; }
+      .cb-main  { padding: 20px 16px 60px; }
+    }
+
+    /* ── Leaderboard panel ── */
+    .cb-panel {
+      border: 1.5px solid var(--border, #e2e8f0);
+      border-radius: 14px;
+      background: var(--surface, #fff);
+      overflow: hidden;
+    }
+
+    .cb-panel-title {
+      padding: 14px 18px;
+      font-family: 'Syne', sans-serif;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      color: var(--text-secondary, #64748b);
+      border-bottom: 1px solid var(--border, #e2e8f0);
+    }
+
+    /* ── Contributor card ── */
+    .cb-card {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      width: 100%;
+      padding: 12px 16px;
+      border: none;
+      border-bottom: 1px solid var(--border, #e2e8f0);
+      background: transparent;
+      cursor: pointer;
+      text-align: left;
+      transition: background 0.15s;
+      font-family: 'DM Sans', sans-serif;
+    }
+
+    .cb-card:last-child { border-bottom: none; }
+    .cb-card:hover      { background: rgba(235,104,53,0.05); }
+
+    .cb-card--active {
+      background: rgba(235,104,53,0.08);
+      border-left: 3px solid #eb6835;
+    }
+
+    .cb-rank {
+      font-size: 12px;
+      font-weight: 700;
+      color: #eb6835;
+      min-width: 24px;
+    }
+
+    .cb-avatar {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      object-fit: cover;
+      flex-shrink: 0;
+      border: 2px solid var(--border, #e2e8f0);
+    }
+
+    .cb-avatar--lg {
+      width: 72px;
+      height: 72px;
+    }
+
+    .cb-info {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .cb-name {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary, #1a2332);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .cb-role {
+      font-size: 11px;
+      color: var(--text-secondary, #64748b);
+    }
+
+    .cb-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 2px;
+    }
+
+    .cb-stat {
+      font-size: 11px;
+      color: var(--text-secondary, #64748b);
+      white-space: nowrap;
+    }
+
+    /* ── Detail panel ── */
+    .cb-detail-panel {
+      border: 1.5px solid var(--border, #e2e8f0);
+      border-radius: 14px;
+      background: var(--surface, #fff);
+      padding: 24px;
+      min-height: 500px;
+    }
+
+    .cb-hint {
+      color: var(--text-secondary, #64748b);
+      text-align: center;
+      padding: 60px 20px;
+      font-size: 14px;
+    }
+
+    .cb-detail-header {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+      margin-bottom: 24px;
+    }
+
+    .cb-detail-meta {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .cb-detail-name {
+      font-family: 'Syne', sans-serif;
+      font-size: 20px;
+      font-weight: 800;
+      margin: 0;
+    }
+
+    .cb-detail-role {
+      font-size: 12px;
+      color: var(--text-secondary, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .cb-github-link {
+      font-size: 13px;
+      color: #eb6835;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .cb-github-link:hover { text-decoration: underline; }
+
+    /* ── Stat cards row ── */
+    .cb-stats-row {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    @media (max-width: 600px) {
+      .cb-stats-row { grid-template-columns: repeat(2, 1fr); }
+    }
+
+    .cb-stat-card {
+      border: 1.5px solid var(--border, #e2e8f0);
+      border-radius: 10px;
+      padding: 12px 14px;
+      text-align: center;
+    }
+
+    .cb-stat-card--accent {
+      background: rgba(235,104,53,0.07);
+      border-color: rgba(235,104,53,0.25);
+    }
+
+    .cb-stat-card__num {
+      display: block;
+      font-family: 'Syne', sans-serif;
+      font-size: 1.5rem;
+      font-weight: 800;
+      color: #eb6835;
+    }
+
+    .cb-stat-card__label {
+      display: block;
+      font-size: 11px;
+      color: var(--text-secondary, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      margin-top: 2px;
+    }
+
+    /* ── Highlight ── */
+    .cb-highlight {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      background: rgba(123,97,255,0.07);
+      border: 1.5px solid rgba(123,97,255,0.2);
+      border-radius: 10px;
+      padding: 10px 16px;
+      margin-bottom: 24px;
+    }
+
+    .cb-highlight__label {
+      font-size: 12px;
+      font-weight: 700;
+      color: #7b61ff;
+      white-space: nowrap;
+    }
+
+    .cb-highlight__link {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary, #1a2332);
+      text-decoration: none;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 1;
+    }
+
+    .cb-highlight__link:hover { color: #7b61ff; }
+
+    .cb-highlight__score {
+      font-size: 12px;
+      color: #7b61ff;
+      background: rgba(123,97,255,0.1);
+      padding: 2px 8px;
+      border-radius: 999px;
+    }
+
+    /* ── Section title ── */
+    .cb-section-title {
+      font-family: 'Syne', sans-serif;
+      font-size: 14px;
+      font-weight: 700;
+      margin: 20px 0 10px;
+      color: var(--text-primary, #1a2332);
+    }
+
+    .cb-section-hint {
+      font-weight: 400;
+      font-size: 12px;
+      color: var(--text-secondary, #64748b);
+    }
+
+    /* ── Component list ── */
+    .cb-comp-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-bottom: 4px;
+    }
+
+    .cb-comp-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 12px;
+      border: 1px solid var(--border, #e2e8f0);
+      border-radius: 8px;
+      text-decoration: none;
+      color: inherit;
+      transition: background 0.15s, border-color 0.15s;
+      font-size: 13px;
+    }
+
+    .cb-comp-row:hover {
+      background: rgba(235,104,53,0.05);
+      border-color: rgba(235,104,53,0.3);
+    }
+
+    .cb-comp-title { font-weight: 600; flex: 1; }
+
+    .cb-comp-cat {
+      font-size: 11px;
+      background: var(--surface-2, #f8fafc);
+      border: 1px solid var(--border, #e2e8f0);
+      border-radius: 4px;
+      padding: 1px 6px;
+      color: var(--text-secondary, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+
+    .cb-comp-metrics {
+      display: flex;
+      gap: 8px;
+      font-size: 12px;
+      color: var(--text-secondary, #64748b);
+    }
+
+    .cb-comp-score {
+      font-weight: 700;
+      color: #eb6835;
+    }
+
+    /* ── Hidden gems ── */
+    .cb-gems {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 4px;
+    }
+
+    .cb-gem-chip {
+      padding: 4px 12px;
+      border-radius: 999px;
+      background: rgba(123,97,255,0.08);
+      border: 1px solid rgba(123,97,255,0.25);
+      color: #7b61ff;
+      font-size: 12px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background 0.15s;
+    }
+
+    .cb-gem-chip:hover { background: rgba(123,97,255,0.18); }
+
+    /* ── Timeline ── */
+    .cb-timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      margin-bottom: 16px;
+      padding-left: 8px;
+    }
+
+    .cb-tl-item {
+      display: flex;
+      gap: 14px;
+      align-items: flex-start;
+      position: relative;
+      padding-bottom: 16px;
+    }
+
+    .cb-tl-item:last-child { padding-bottom: 0; }
+
+    .cb-tl-item:not(:last-child)::before {
+      content: '';
+      position: absolute;
+      left: 7px;
+      top: 16px;
+      bottom: 0;
+      width: 2px;
+      background: var(--border, #e2e8f0);
+    }
+
+    .cb-tl-dot {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      border: 2px solid var(--border, #e2e8f0);
+      background: var(--surface, #fff);
+      flex-shrink: 0;
+      margin-top: 2px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .cb-tl-dot--first {
+      border-color: #eb6835;
+      background: #eb6835;
+    }
+
+    .cb-tl-body {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .cb-tl-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary, #1a2332);
+      text-decoration: none;
+    }
+
+    .cb-tl-title:hover { color: #eb6835; }
+
+    .cb-tl-date {
+      font-size: 11px;
+      color: var(--text-secondary, #64748b);
+    }
+
+    /* ── Footer ── */
+    .cb-joined {
+      font-size: 12px;
+      color: var(--text-secondary, #64748b);
+      text-align: right;
+      margin-top: 8px;
+    }
+
+    /* ── States ── */
+    #cbLoading {
+      text-align: center;
+      padding: 60px;
+      color: var(--text-secondary, #64748b);
+      font-size: 14px;
+    }
+
+    #cbError {
+      display: none;
+      text-align: center;
+      padding: 40px;
+      color: #ef4444;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+
+<!-- ================= SIDEBAR ================= -->
+<aside class="sidebar" id="sidebar">
+  <div class="sidebar-brand">
+    <span class="brand-icon">⬡</span>
+    <span class="brand-text">UIverse <span style="font-size:9px;background:linear-gradient(135deg,#eb6835,#7b61ff);color:#fff;padding:1px 6px;border-radius:10px;font-weight:800;margin-left:4px;">V2</span></span>
+  </div>
+  <nav class="sidebar-nav">
+    <ul>
+      <li><a href="index.html"><i class="fa-solid fa-house"></i><span>Home</span></a></li>
+      <li><a href="button.html"><i class="fa-solid fa-hand-pointer"></i><span>Buttons</span></a></li>
+      <li><a href="cards.html"><i class="fa-solid fa-table-cells-large"></i><span>Cards</span></a></li>
+      <li><a href="forms.html"><i class="fa-brands fa-wpforms"></i><span>Forms</span></a></li>
+      <li><a href="navbar.html"><i class="fa-solid fa-bars"></i><span>Navbar</span></a></li>
+      <li><a href="loaders.html"><i class="fa-solid fa-spinner"></i><span>Loaders</span></a></li>
+      <li><a href="charts.html"><i class="fa-solid fa-chart-pie"></i><span>Charts</span></a></li>
+      <li><a href="about.html"><i class="fa-solid fa-circle-info"></i><span>About</span></a></li>
+      <li><a href="documentation.html"><i class="fa-solid fa-book"></i><span>Documentation</span></a></li>
+      <li class="active"><a href="contributor-dashboard.html"><i class="fa-solid fa-users"></i><span>Contributors</span></a></li>
+    </ul>
+  </nav>
+  <div class="sidebar-footer">
+    <a href="#" title="GitHub"><i class="fab fa-github"></i></a>
+    <a href="#" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
+    <a href="#" title="Twitter"><i class="fab fa-x-twitter"></i></a>
+  </div>
+</aside>
+
+<!-- ================= SIDEBAR BACKDROP ================= -->
+<div class="sidebar-backdrop" id="sidebarBackdrop" onclick="toggleSidebar()"></div>
+
+<!-- ================= NAVBAR ================= -->
+<header class="navbar" id="navbar">
+  <button class="menu-toggle" onclick="toggleSidebar()" aria-label="Toggle Menu">
+    <i class="fa-solid fa-bars"></i>
+  </button>
+  <div class="logo">UIverse</div>
+  <div class="nav-right">
+    <button id="darkModeToggle" class="theme-toggle" title="Toggle Theme">
+      <i class="fa-solid fa-moon"></i>
+    </button>
+  </div>
+</header>
+
+<!-- ================= MAIN ================= -->
+<main class="cb-main">
+
+  <div class="cb-page-header">
+    <h1>Contributor <span>Impact Dashboard</span></h1>
+    <p>Per-contributor component stats, adoption metrics, and activity timeline.</p>
+  </div>
+
+  <div id="cbLoading">Loading contributors…</div>
+  <div id="cbError">Failed to load contributor data. Make sure you are running on a local server.</div>
+
+  <div class="cb-toolbar">
+    <input
+      type="text"
+      id="cbSearch"
+      class="cb-search"
+      placeholder="Search contributors…"
+      autocomplete="off"
+    />
+    <select id="cbSort" class="cb-sort" aria-label="Sort contributors">
+      <option value="impact">Sort: Impact Score</option>
+      <option value="components">Sort: Most Components</option>
+      <option value="joined">Sort: Earliest Joined</option>
+    </select>
+  </div>
+
+  <div class="cb-split">
+    <div class="cb-panel">
+      <div class="cb-panel-title">Contributors</div>
+      <div id="cbLeaderboard"></div>
+    </div>
+    <div class="cb-detail-panel" id="cbDetail">
+      <p class="cb-hint">← Select a contributor to see their impact</p>
+    </div>
+  </div>
+
+</main>
+
+<!-- ================= FOOTER ================= -->
+<footer class="footer">
+  <div class="footer-container">
+    <div class="footer-col brand">
+      <h2 class="footer-logo">⬡ UIverse</h2>
+      <p>Build modern, reusable UI components with clean HTML, CSS, and JavaScript.</p>
+    </div>
+    <div class="footer-col">
+      <h3>Explore</h3>
+      <ul>
+        <li><a href="button.html">Buttons</a></li>
+        <li><a href="navbar.html">Navbars</a></li>
+        <li><a href="cards.html">Cards</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <p>© 2026 UIverse. Made with ❤️ for developers worldwide.</p>
+  </div>
+</footer>
+
+<!-- ================= SCROLL TO TOP ================= -->
+<button id="scrollTopBtn" onclick="scrollToTop()" title="Back to top">
+  <i class="fa-solid fa-chevron-up"></i>
+</button>
+
+<script src="js/core/analytics.js"></script>
+<script src="js/features/contributor-dashboard.js"></script>
+<script>
+  /* ── Dark mode ── */
+  const _dmBtn  = document.getElementById('darkModeToggle');
+  const _dmIcon = _dmBtn.querySelector('i');
+  if (localStorage.getItem('theme') === 'dark') {
+    document.body.classList.add('dark-mode');
+    _dmIcon.className = 'fa-solid fa-sun';
+  }
+  _dmBtn.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const dark = document.body.classList.contains('dark-mode');
+    _dmIcon.className = dark ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  });
+
+  /* ── Sidebar ── */
+  function toggleSidebar() {
+    document.getElementById('sidebar').classList.toggle('open');
+    document.getElementById('sidebarBackdrop').classList.toggle('visible');
+  }
+
+  /* ── Scroll top ── */
+  function scrollToTop() { window.scrollTo({ top: 0, behavior: 'smooth' }); }
+  window.addEventListener('scroll', () => {
+    document.getElementById('scrollTopBtn').classList.toggle('visible', window.scrollY > 400);
+    document.getElementById('navbar').classList.toggle('scrolled', window.scrollY > 40);
+  });
+
+  /* ── Boot dashboard ── */
+  document.addEventListener('DOMContentLoaded', () => {
+    ContributorDashboard.init();
+  });
+</script>
+
+</body>
+</html>

--- a/data/contributors.json
+++ b/data/contributors.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "tushar-sonawane",
+    "name": "Tushar Sonawane",
+    "github": "Tushar-sonawane06",
+    "avatar": "https://avatars.githubusercontent.com/Tushar-sonawane06",
+    "role": "Project Admin",
+    "joinedAt": "2024-01-01",
+    "components": [
+      { "id": "button",        "title": "Buttons",          "path": "button.html",        "addedAt": "2024-01-10", "category": "components" },
+      { "id": "navbar",        "title": "Navbar",            "path": "navbar.html",        "addedAt": "2024-01-15", "category": "navigation" },
+      { "id": "cards",         "title": "Cards",             "path": "cards.html",         "addedAt": "2024-01-20", "category": "components" },
+      { "id": "badges",        "title": "Badges",            "path": "badges.html",        "addedAt": "2024-02-01", "category": "components" },
+      { "id": "alerts",        "title": "Alerts",            "path": "alerts.html",        "addedAt": "2024-02-10", "category": "components" }
+    ]
+  },
+  {
+    "id": "priya-sharma",
+    "name": "Priya Sharma",
+    "github": "priya-sharma-dev",
+    "avatar": "https://avatars.githubusercontent.com/priya-sharma-dev",
+    "role": "Contributor",
+    "joinedAt": "2024-02-15",
+    "components": [
+      { "id": "forms",         "title": "Forms",             "path": "forms.html",         "addedAt": "2024-02-20", "category": "forms" },
+      { "id": "inputs",        "title": "Inputs",            "path": "inputs.html",        "addedAt": "2024-03-01", "category": "forms" },
+      { "id": "checkbox",      "title": "Checkboxes",        "path": "checkbox.html",      "addedAt": "2024-03-10", "category": "forms" },
+      { "id": "radiobutton",   "title": "Radio Buttons",     "path": "radiobutton.html",   "addedAt": "2024-03-20", "category": "forms" }
+    ]
+  },
+  {
+    "id": "arjun-mehta",
+    "name": "Arjun Mehta",
+    "github": "arjun-mehta-ui",
+    "avatar": "https://avatars.githubusercontent.com/arjun-mehta-ui",
+    "role": "Contributor",
+    "joinedAt": "2024-03-05",
+    "components": [
+      { "id": "loaders",       "title": "Loaders",           "path": "loaders.html",       "addedAt": "2024-03-10", "category": "components" },
+      { "id": "flipcards",     "title": "3D Flip Cards",     "path": "flipcards.html",     "addedAt": "2024-03-25", "category": "components" },
+      { "id": "hover",         "title": "Hover Effects",     "path": "hover.html",         "addedAt": "2024-04-05", "category": "effects" }
+    ]
+  },
+  {
+    "id": "sara-okonkwo",
+    "name": "Sara Okonkwo",
+    "github": "sara-okonkwo",
+    "avatar": "https://avatars.githubusercontent.com/sara-okonkwo",
+    "role": "Contributor",
+    "joinedAt": "2024-04-01",
+    "components": [
+      { "id": "charts",        "title": "Charts",            "path": "charts.html",        "addedAt": "2024-04-10", "category": "data" },
+      { "id": "dashboard",     "title": "Dashboard",         "path": "dashboard.html",     "addedAt": "2024-04-20", "category": "apps" },
+      { "id": "table",         "title": "Tables",            "path": "table.html",         "addedAt": "2024-05-01", "category": "data" },
+      { "id": "timeline",      "title": "Timeline",          "path": "timeline.html",      "addedAt": "2024-05-10", "category": "components" },
+      { "id": "widgets",       "title": "Widgets",           "path": "widgets.html",       "addedAt": "2024-05-20", "category": "components" }
+    ]
+  },
+  {
+    "id": "liam-chen",
+    "name": "Liam Chen",
+    "github": "liam-chen-dev",
+    "avatar": "https://avatars.githubusercontent.com/liam-chen-dev",
+    "role": "Contributor",
+    "joinedAt": "2024-05-15",
+    "components": [
+      { "id": "auth",          "title": "Authentication",    "path": "auth.html",          "addedAt": "2024-05-20", "category": "pages" },
+      { "id": "recovery",      "title": "Password Recovery", "path": "recovery.html",      "addedAt": "2024-06-01", "category": "pages" },
+      { "id": "pricing",       "title": "Pricing",           "path": "pricing.html",       "addedAt": "2024-06-10", "category": "pages" },
+      { "id": "subscription",  "title": "Subscription",      "path": "subscription.html",  "addedAt": "2024-06-20", "category": "pages" }
+    ]
+  },
+  {
+    "id": "fatima-al-rashid",
+    "name": "Fatima Al-Rashid",
+    "github": "fatima-alrashid",
+    "avatar": "https://avatars.githubusercontent.com/fatima-alrashid",
+    "role": "Contributor",
+    "joinedAt": "2024-06-15",
+    "components": [
+      { "id": "hero",          "title": "Hero Sections",     "path": "hero.html",          "addedAt": "2024-06-20", "category": "layout" },
+      { "id": "footer",        "title": "Footer",            "path": "footer.html",        "addedAt": "2024-07-01", "category": "layout" },
+      { "id": "testimonials",  "title": "Testimonials",      "path": "testimonials.html",  "addedAt": "2024-07-10", "category": "components" },
+      { "id": "ecommerce",     "title": "E-commerce",        "path": "ecommerce.html",     "addedAt": "2024-07-20", "category": "apps" }
+    ]
+  },
+  {
+    "id": "dev-patel",
+    "name": "Dev Patel",
+    "github": "dev-patel-codes",
+    "avatar": "https://avatars.githubusercontent.com/dev-patel-codes",
+    "role": "Contributor",
+    "joinedAt": "2024-07-10",
+    "components": [
+      { "id": "tabs",               "title": "Tabs",               "path": "tabs.html",               "addedAt": "2024-07-15", "category": "navigation" },
+      { "id": "toggles",            "title": "Toggles",            "path": "toggles.html",            "addedAt": "2024-07-25", "category": "components" },
+      { "id": "notifications-premium", "title": "Notifications V2", "path": "notifications-premium.html", "addedAt": "2024-08-05", "category": "components" },
+      { "id": "step-indicators",    "title": "Steppers",           "path": "step-indicators.html",    "addedAt": "2024-08-15", "category": "components" },
+      { "id": "progress-premium",   "title": "Progress V2",        "path": "progress-premium.html",   "addedAt": "2024-08-25", "category": "components" }
+    ]
+  },
+  {
+    "id": "nina-kowalski",
+    "name": "Nina Kowalski",
+    "github": "nina-kowalski",
+    "avatar": "https://avatars.githubusercontent.com/nina-kowalski",
+    "role": "Contributor",
+    "joinedAt": "2024-08-20",
+    "components": [
+      { "id": "search",        "title": "Search Bars",       "path": "search.html",        "addedAt": "2024-08-25", "category": "components" },
+      { "id": "dropdown-components", "title": "Dropdowns",   "path": "dropdown-components.html", "addedAt": "2024-09-05", "category": "navigation" },
+      { "id": "menu",          "title": "Menu",              "path": "menu.html",          "addedAt": "2024-09-15", "category": "navigation" }
+    ]
+  }
+]

--- a/js/features/contributor-dashboard.js
+++ b/js/features/contributor-dashboard.js
@@ -1,0 +1,300 @@
+// =========================================================
+// CONTRIBUTOR IMPACT DASHBOARD
+// Loads contributor metadata, merges with analytics data,
+// and renders per-contributor stats + activity timeline.
+// =========================================================
+
+const ContributorDashboard = (() => {
+
+  // ── State ─────────────────────────────────────────────
+  const _state = {
+    contributors: [],
+    activeId:     null,   // currently selected contributor
+    sortBy:       'impact' // 'impact' | 'components' | 'joined'
+  };
+
+  // ── Analytics integration ─────────────────────────────
+
+  function getMetrics(componentId) {
+    if (window.ComponentAnalytics) {
+      return window.ComponentAnalytics.getMetrics(componentId);
+    }
+    try {
+      const raw  = localStorage.getItem('uiv-analytics');
+      const data = raw ? JSON.parse(raw) : {};
+      return data[componentId] || { views: 0, copies: 0, likes: 0 };
+    } catch (_) {
+      return { views: 0, copies: 0, likes: 0 };
+    }
+  }
+
+  function adoptionScore(metrics) {
+    return (metrics.views || 0) +
+           (metrics.copies || 0) * 2 +
+           (metrics.likes  || 0) * 3;
+  }
+
+  // ── Data loading ──────────────────────────────────────
+
+  async function load() {
+    const res  = await fetch('data/contributors.json');
+    if (!res.ok) throw new Error('Failed to load contributors.json');
+    const raw  = await res.json();
+
+    _state.contributors = raw.map(contributor => {
+      const enriched = contributor.components.map(comp => ({
+        ...comp,
+        metrics: getMetrics(comp.id),
+        score:   adoptionScore(getMetrics(comp.id))
+      }));
+
+      const totalScore = enriched.reduce((s, c) => s + c.score, 0);
+      const topComp    = enriched.slice().sort((a, b) => b.score - a.score)[0] || null;
+      const hidden     = enriched.filter(c => c.score < 3);
+
+      return {
+        ...contributor,
+        components:  enriched,
+        totalScore,
+        topComponent: topComp,
+        hiddenGems:   hidden
+      };
+    });
+
+    return _state.contributors;
+  }
+
+  // ── Sorting ───────────────────────────────────────────
+
+  function sorted() {
+    const list = _state.contributors.slice();
+    if (_state.sortBy === 'impact') {
+      return list.sort((a, b) => b.totalScore - a.totalScore);
+    }
+    if (_state.sortBy === 'components') {
+      return list.sort((a, b) => b.components.length - a.components.length);
+    }
+    if (_state.sortBy === 'joined') {
+      return list.sort((a, b) => new Date(a.joinedAt) - new Date(b.joinedAt));
+    }
+    return list;
+  }
+
+  // ── Formatting helpers ────────────────────────────────
+
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  function escHtml(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  // ── Render: leaderboard list ──────────────────────────
+
+  function renderLeaderboard(container) {
+    const list = sorted();
+    container.innerHTML = list.map((c, i) => `
+      <button
+        class="cb-card ${_state.activeId === c.id ? 'cb-card--active' : ''}"
+        data-id="${escHtml(c.id)}"
+        aria-pressed="${_state.activeId === c.id}"
+      >
+        <span class="cb-rank">#${i + 1}</span>
+        <img
+          class="cb-avatar"
+          src="${escHtml(c.avatar)}"
+          alt="${escHtml(c.name)}"
+          onerror="this.src='https://ui-avatars.com/api/?name=${encodeURIComponent(c.name)}&background=eb6835&color=fff&size=48'"
+        />
+        <span class="cb-info">
+          <span class="cb-name">${escHtml(c.name)}</span>
+          <span class="cb-role">${escHtml(c.role)}</span>
+        </span>
+        <span class="cb-meta">
+          <span class="cb-stat" title="Impact score">⚡ ${c.totalScore}</span>
+          <span class="cb-stat" title="Components">🧩 ${c.components.length}</span>
+        </span>
+      </button>
+    `).join('');
+  }
+
+  // ── Render: detail panel ──────────────────────────────
+
+  function renderDetail(container, contributor) {
+    if (!contributor) {
+      container.innerHTML = '<p class="cb-hint">← Select a contributor to see their impact</p>';
+      return;
+    }
+
+    const c       = contributor;
+    const byScore = c.components.slice().sort((a, b) => b.score - a.score);
+
+    // Timeline: sort by addedAt
+    const timeline = c.components.slice().sort(
+      (a, b) => new Date(a.addedAt) - new Date(b.addedAt)
+    );
+
+    container.innerHTML = `
+      <div class="cb-detail-header">
+        <img
+          class="cb-avatar cb-avatar--lg"
+          src="${escHtml(c.avatar)}"
+          alt="${escHtml(c.name)}"
+          onerror="this.src='https://ui-avatars.com/api/?name=${encodeURIComponent(c.name)}&background=eb6835&color=fff&size=80'"
+        />
+        <div class="cb-detail-meta">
+          <h2 class="cb-detail-name">${escHtml(c.name)}</h2>
+          <span class="cb-detail-role">${escHtml(c.role)}</span>
+          <a
+            class="cb-github-link"
+            href="https://github.com/${escHtml(c.github)}"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <i class="fab fa-github"></i> @${escHtml(c.github)}
+          </a>
+        </div>
+      </div>
+
+      <div class="cb-stats-row">
+        <div class="cb-stat-card">
+          <span class="cb-stat-card__num">${c.components.length}</span>
+          <span class="cb-stat-card__label">Components</span>
+        </div>
+        <div class="cb-stat-card cb-stat-card--accent">
+          <span class="cb-stat-card__num">${c.totalScore}</span>
+          <span class="cb-stat-card__label">Impact Score</span>
+        </div>
+        <div class="cb-stat-card">
+          <span class="cb-stat-card__num">${c.components.reduce((s, x) => s + (x.metrics.views || 0), 0)}</span>
+          <span class="cb-stat-card__label">Total Views</span>
+        </div>
+        <div class="cb-stat-card">
+          <span class="cb-stat-card__num">${c.components.reduce((s, x) => s + (x.metrics.copies || 0), 0)}</span>
+          <span class="cb-stat-card__label">Total Copies</span>
+        </div>
+      </div>
+
+      ${c.topComponent ? `
+      <div class="cb-highlight">
+        <span class="cb-highlight__label">🏆 Top Component</span>
+        <a href="${escHtml(c.topComponent.path)}" class="cb-highlight__link">
+          ${escHtml(c.topComponent.title)}
+          <span class="cb-highlight__score">⚡ ${c.topComponent.score}</span>
+        </a>
+      </div>` : ''}
+
+      <h3 class="cb-section-title">All Components</h3>
+      <div class="cb-comp-list">
+        ${byScore.map(comp => `
+          <a class="cb-comp-row" href="${escHtml(comp.path)}">
+            <span class="cb-comp-title">${escHtml(comp.title)}</span>
+            <span class="cb-comp-cat">${escHtml(comp.category)}</span>
+            <span class="cb-comp-metrics">
+              <span title="Views">👁 ${comp.metrics.views || 0}</span>
+              <span title="Copies">📋 ${comp.metrics.copies || 0}</span>
+              <span title="Likes">❤️ ${comp.metrics.likes || 0}</span>
+              <span class="cb-comp-score" title="Impact score">⚡ ${comp.score}</span>
+            </span>
+          </a>
+        `).join('')}
+      </div>
+
+      ${c.hiddenGems.length ? `
+      <h3 class="cb-section-title">💎 Hidden Gems <span class="cb-section-hint">(low views — worth exploring)</span></h3>
+      <div class="cb-gems">
+        ${c.hiddenGems.map(g => `
+          <a class="cb-gem-chip" href="${escHtml(g.path)}">${escHtml(g.title)}</a>
+        `).join('')}
+      </div>` : ''}
+
+      <h3 class="cb-section-title">📅 Activity Timeline</h3>
+      <div class="cb-timeline">
+        ${timeline.map((comp, idx) => `
+          <div class="cb-tl-item">
+            <div class="cb-tl-dot ${idx === 0 ? 'cb-tl-dot--first' : ''}"></div>
+            <div class="cb-tl-body">
+              <a class="cb-tl-title" href="${escHtml(comp.path)}">${escHtml(comp.title)}</a>
+              <span class="cb-tl-date">${fmtDate(comp.addedAt)}</span>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+
+      <p class="cb-joined">Member since ${fmtDate(c.joinedAt)}</p>
+    `;
+  }
+
+  // ── Init ──────────────────────────────────────────────
+
+  async function init(options) {
+    const leaderboardEl = document.getElementById('cbLeaderboard');
+    const detailEl      = document.getElementById('cbDetail');
+    const sortEl        = document.getElementById('cbSort');
+    const searchEl      = document.getElementById('cbSearch');
+    const loadingEl     = document.getElementById('cbLoading');
+    const errorEl       = document.getElementById('cbError');
+
+    if (!leaderboardEl || !detailEl) return;
+
+    try {
+      await load();
+    } catch (err) {
+      if (loadingEl) loadingEl.style.display = 'none';
+      if (errorEl)   errorEl.style.display   = '';
+      console.error('[ContributorDashboard]', err);
+      return;
+    }
+
+    if (loadingEl) loadingEl.style.display = 'none';
+
+    // Default: select first contributor
+    if (_state.contributors.length) {
+      _state.activeId = _state.contributors[0].id;
+    }
+
+    renderLeaderboard(leaderboardEl);
+    renderDetail(detailEl, _state.contributors.find(c => c.id === _state.activeId));
+
+    // Click on contributor card
+    leaderboardEl.addEventListener('click', e => {
+      const btn = e.target.closest('.cb-card');
+      if (!btn) return;
+      _state.activeId = btn.dataset.id;
+      renderLeaderboard(leaderboardEl);
+      renderDetail(detailEl, _state.contributors.find(c => c.id === _state.activeId));
+    });
+
+    // Sort change
+    if (sortEl) {
+      sortEl.addEventListener('change', () => {
+        _state.sortBy = sortEl.value;
+        renderLeaderboard(leaderboardEl);
+      });
+    }
+
+    // Search filter
+    if (searchEl) {
+      searchEl.addEventListener('input', () => {
+        const q = searchEl.value.toLowerCase().trim();
+        leaderboardEl.querySelectorAll('.cb-card').forEach(btn => {
+          const name = btn.querySelector('.cb-name')?.textContent.toLowerCase() || '';
+          btn.style.display = name.includes(q) ? '' : 'none';
+        });
+      });
+    }
+  }
+
+  // ── Expose ────────────────────────────────────────────
+
+  return { init, load };
+
+})();
+
+window.ContributorDashboard = ContributorDashboard;


### PR DESCRIPTION
## Summary
Implements #3438 — a dedicated Contributor Impact Dashboard that surfaces per-contributor component stats, adoption metrics, and an activity timeline.

## Changes by file
- **data/contributors.json** (new): Seed data mapping 8 contributors to their respective components with join dates and component add dates
- **js/features/contributor-dashboard.js** (new): Core engine — loads contributor data, merges with ComponentAnalytics localStorage metrics, computes adoption scores, detects hidden gems, renders leaderboard and detail panel
- **contributor-dashboard.html** (new): Full page with split-panel layout — contributor leaderboard (left) + detail view (right) with stat cards, top component highlight, component list, hidden gems, and timeline

## Technical Notes
- Adoption score formula: views × 1 + copies × 2 + likes × 3 (matches existing analytics weight)
- Hidden gems = components with adoption score < 3
- Fully client-side — no server required beyond static file serving (needed for fetch)
- Degrades gracefully when ComponentAnalytics has no data yet
- Consistent with existing page patterns: same sidebar, navbar, dark mode, scroll-to-top

Closes #3438