### PR TITLE
fix(meta): configure mobile viewport on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
+    <meta name="description" content="Oops! The page you were looking for on UIverse was not found. Browse our high quality CSS components." />
     <title>404 – Page Not Found | UI-verse</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400&display=swap"


### PR DESCRIPTION
## Related Issue
Closes #3653 

## Summary
Improves responsive scaling controls on the 404 error page.

## Changes Made
- Modified the `<meta>` viewport rules and added search engine description definitions to the head in `404.html`.

## Testing & Verification
1. **Local Test Command:** Verified 404 mobile responsiveness at 320px viewport.

## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
