### PR TITLE
fix(versioning): support flexible date formats in metadata check

### DIFF
--- a/scripts/component-metadata.js
+++ b/scripts/component-metadata.js
@@ -190,7 +190,8 @@ function buildVersioningState(options = {}){
         if(!entry || !isSemver(entry.version)){
           errors.push(`[${id}] Changelog entry #${index + 1} has invalid version.`);
         }
-        if(!entry || !/^\d{4}-\d{2}-\d{2}$/.test(String(entry.date || ''))){
+        const parsedDate = Date.parse(String(entry.date || ''));
+        if(!entry || (isNaN(parsedDate) && !/^\d{4}-\d{2}-\d{2}$/.test(String(entry.date || '')))){
           errors.push(`[${id}] Changelog entry #${index + 1} has invalid date.`);
         }
       });


### PR DESCRIPTION
## Related Issue
Closes #3661

## Summary
This PR fixes the date validation logic in `scripts/component-metadata.js` to handle full-timestamp date values and different timezone offsets correctly.

## Changes Made
- Modified the changelog check loop in `scripts/component-metadata.js` to parse dates via `Date.parse()` in addition to testing for standard YYYY-MM-DD format.

## Testing & Verification
1. **Local Test Command:** `npm run components:version:check`
2. **Browsers Checked:** N/A (Node CLI utility)
3. **Responsive Verification:** N/A

## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
