### PR TITLE
invalid HTML attribute syntax in the search input field solved

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
 
   <div class="search-bar">
     <i class="fa-solid fa-magnifying-glass search-icon"></i>
-    <input type="text" id="searchInput" placeholder="Search components..." aria-label="Search components" / data-a11y-remediation="label-needed">
+    <input type="text" id="searchInput" placeholder="Search components..." aria-label="Search components" data-a11y-remediation="label-needed">
     <kbd class="search-kbd">⌘K</kbd>
   </div>
 


### PR DESCRIPTION
Related Issue
Closes #3623

Summary
This pull request removes a stray forward slash (/) from the search <input> field (around line 150) in index.html. The misplaced slash was located directly before the data-a11y-remediation attribute, resulting in invalid HTML syntax. Removing it ensures the document parses correctly and adheres to HTML5 validation standards.

Changes Made
[x] Added/modified the component file(s) (index.html)

[ ] Updated companion stylesheet/CSS file(s)

[ ] Documented properties and usage in relevant markdown/docs

Technical Details & Scope
Component Category: Form / Navigation (Search Input)

Impact Radius: index.html (Specifically the global search bar element in the UI)

Testing & Verification
Please describe how you verified the changes:

Local Test Command: Passed the modified index.html through the W3C HTML Validator to confirm the syntax error is resolved.

Browsers Checked: Chrome, Firefox, Safari (verified that the DOM parses the input attributes correctly without the stray slash).

Responsive Verification: Confirmed the search bar layout remains intact and functional across 320px, 768px, and 1024px widths.

Screenshots
N/A — This is a structural HTML syntax fix only. There are no visual changes to the UI.

Checklist
[x] Code follows project conventions and style guidelines

[x] Tested locally and confirmed all quality gates pass

[x] No unrelated changes or debug statements included

[x] Component metadata version and changelog updated if necessary