### PR TITLE
malformed HTML list nesting in the sidebar navigation solved

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,12 +117,12 @@
           <i class="fa-solid fa-award"></i>
           <span>Loaders</span>
         </a>
-        <li>
+      </li>
+      <li>
         <a href="about.html">
           <i class="fa-solid fa-award"></i>
           <span>About us</span>
         </a>
-      </li>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION

Related Issue
Closes #3439

Summary
This pull request fixes malformed HTML list nesting in the sidebar navigation (around lines 116-127). It resolves a mismatched closing </li> tag and ensures the "About us" link is properly wrapped in its own <li> element rather than a duplicate opening tag. This restores semantic validity and prevents potential rendering bugs.

Changes Made
[x] Added/modified the component file(s) (index.html)

[ ] Updated companion stylesheet/CSS file(s)

[ ] Documented properties and usage in relevant markdown/docs

Technical Details & Scope
Component Category: Navigation / Sidebar

Impact Radius: index.html (Specifically the sidebar navigation structure)

Testing & Verification
Please describe how you verified the changes:

Local Test Command: Passed index.html through the W3C HTML Validator to ensure there are no remaining unclosed or mismatched tags in the sidebar block.

Browsers Checked: Chrome, Firefox, Safari (verified that the DOM tree parses the list items accurately and without unexpected nesting).

Responsive Verification: Verified that the visual layout of the sidebar remains intact across standard breakpoints (320px, 768px, 1024px).

Screenshots
N/A — This is a structural HTML syntax fix only. There are no visual changes to the UI.

Checklist
[x] Code follows project conventions and style guidelines

[x] Tested locally and confirmed all quality gates pass

[x] No unrelated changes or debug statements included

[x] Component metadata version and changelog updated if necessary