### PR TITLE
Feat(wb): Flood fill tool in whiteboard page

### DIFF
--- a/whiteboard/wb.css
+++ b/whiteboard/wb.css
@@ -224,6 +224,10 @@ body{
   cursor: crosshair;
 }
 
+#canvas.fill-mode {
+  cursor: cell;
+}
+
 @media(max-width: 700px){
 
   .toolbar{

--- a/whiteboard/wb.html
+++ b/whiteboard/wb.html
@@ -37,8 +37,10 @@
           <button type="button" class="tool-btn" id="eraserBtn" title="Eraser" aria-pressed="false">
             <i class="fa-solid fa-eraser"></i>
           </button>
+          <button type="button" class="tool-btn" id="fillBtn" title="Fill" aria-pressed="false">
+            <i class="fa-solid fa-fill-drip"></i>
+          </button>
         </div>
-
         <button id="clearBtn">
           Clear
         </button>

--- a/whiteboard/wb.js
+++ b/whiteboard/wb.js
@@ -5,6 +5,7 @@ const brushSize = document.getElementById("brushSize");
 const clearBtn = document.getElementById("clearBtn");
 const brushBtn = document.getElementById("brushBtn");
 const eraserBtn = document.getElementById("eraserBtn");
+const fillBtn = document.getElementById("fillBtn");
 
 canvas.width = canvas.offsetWidth;
 canvas.height = canvas.offsetHeight;
@@ -25,18 +26,23 @@ colorPicker.addEventListener("input", e => {
 canvas.addEventListener("mousedown", () => { drawing = true; });
 canvas.addEventListener("mouseup", () => { drawing = false; ctx.beginPath(); });
 canvas.addEventListener("mousemove", draw);
+canvas.addEventListener("click", (e) => {
+  if (!fillBtn.classList.contains("active")) return;
+  floodFill(e.offsetX, e.offsetY, currentColor);
+});
 
 function setActiveTool(tool) {
-  [brushBtn, eraserBtn].forEach(b => {
+  [brushBtn, eraserBtn, fillBtn].forEach(b => {
     b.classList.remove("active", "just-activated");
     b.setAttribute("aria-pressed", "false");
   });
   tool.classList.add("active");
   tool.setAttribute("aria-pressed", "true");
-  void tool.offsetWidth; // reflow to restart animation
+  void tool.offsetWidth;
   tool.classList.add("just-activated");
+  
+  canvas.classList.toggle("fill-mode", tool === fillBtn);
 }
-
 function draw(e) {
   if (!drawing) return;
   ctx.lineWidth = brushSize.value;
@@ -64,6 +70,10 @@ eraserBtn.addEventListener("click", () => {
   setActiveTool(eraserBtn);
 });
 
+fillBtn.addEventListener("click", () => {
+  setActiveTool(fillBtn);
+});
+
 let selectedFormat = "png";
 
 function saveCanvas() {
@@ -74,6 +84,51 @@ function saveCanvas() {
   link.href      = dataURL;
   link.download  = `drawing.${selectedFormat}`;
   link.click();
+}
+
+function floodFill(startX, startY, fillColor) {
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+
+  const toIndex = (x, y) => (y * canvas.width + x) * 4;
+  const idx = toIndex(Math.floor(startX), Math.floor(startY));
+  const target = [data[idx], data[idx+1], data[idx+2], data[idx+3]];
+
+  // Parse fill colour to RGBA
+  const tmp = document.createElement("canvas");
+  tmp.width = tmp.height = 1;
+  const tmpCtx = tmp.getContext("2d");
+  tmpCtx.fillStyle = fillColor;
+  tmpCtx.fillRect(0, 0, 1, 1);
+  const [fr, fg, fb, fa] = tmpCtx.getImageData(0, 0, 1, 1).data;
+
+  if (target[0]===fr && target[1]===fg && target[2]===fb && target[3]===fa) return;
+
+  const match = (i) =>
+    data[i]===target[0] && data[i+1]===target[1] &&
+    data[i+2]===target[2] && data[i+3]===target[3];
+
+  const stack = [Math.floor(startX) + Math.floor(startY) * canvas.width];
+  const visited = new Uint8Array(canvas.width * canvas.height);
+
+  while (stack.length) {
+    const pos = stack.pop();
+    if (visited[pos]) continue;
+    visited[pos] = 1;
+
+    const i = pos * 4;
+    if (!match(i)) continue;
+
+    data[i] = fr; data[i+1] = fg; data[i+2] = fb; data[i+3] = fa;
+
+    const x = pos % canvas.width, y = Math.floor(pos / canvas.width);
+    if (x > 0)               stack.push(pos - 1);
+    if (x < canvas.width-1)  stack.push(pos + 1);
+    if (y > 0)               stack.push(pos - canvas.width);
+    if (y < canvas.height-1) stack.push(pos + canvas.width);
+  }
+
+  ctx.putImageData(imageData, 0, 0);
 }
 
 function injectSaveControls() {


### PR DESCRIPTION
## Related Issue
Closes #3815 

## Summary
Adds a flood-fill (bucket) tool to the Digital Whiteboard component. Users can now click any enclosed region on the canvas to fill it with the currently selected colour, complementing the existing brush and eraser tools.

## Changes Made
- [x] Added/modified the component file(s)
- [x] Updated companion stylesheet/CSS file(s)
- [ ] Documented properties and usage in relevant markdown/docs

## Technical Details & Scope
- **Component Category:** Canvas / Drawing Tool
- **Impact Radius:** `wb.html`, `wb.js`, `wb.css` — isolated to the whiteboard component; no shared or global assets touched
- **Implementation:** Stack-based flood fill operating directly on `ImageData` pixels. Avoids recursion to prevent call-stack overflow on large canvases. Colour matching is exact (RGBA). Cursor switches to `cell` when fill mode is active.

## Testing & Verification
1. **Local Test Command:** `npm run components:version:check` / `npm run audit:a11y`
2. **Browsers Checked:** Chrome, Firefox, Safari, Edge
3. **Responsive Verification:** Tested at 320px, 768px, and 1024px widths; toolbar wraps correctly on narrow viewports

## Screenshots
<img width="952" height="532" alt="image" src="https://github.com/user-attachments/assets/008ae684-b15a-48c6-889d-b4f32be0682e" />

## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
- [x] Component metadata version and changelog updated if necessary