### PR TITLE
feat: add responsive Back-to-Top button on Carousel Page

### DIFF
--- a/carousel.css
+++ b/carousel.css
@@ -1238,3 +1238,24 @@ body.dark-mode .testimonial-card p {
     transform:translateX(-50%);
   }
 }
+
+#backToTop {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 9999; /* make sure it's above footer */
+  border: none;
+  background: #4CAF50;
+  color: #fff;
+  cursor: pointer;
+  padding: 14px;
+  border-radius: 50%;
+  font-size: 18px;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.2);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+#backToTop:hover {
+  background: #45a049;
+  transform: scale(1.1);
+}

--- a/carousel.html
+++ b/carousel.html
@@ -763,6 +763,10 @@
   </div>
 </footer>
 
+<!-- Back-to-Top Button -->
+<button id="backToTop" title="Go to top">↑</button>
+
+
 </body>
 </html>
 

--- a/carousel.js
+++ b/carousel.js
@@ -1,0 +1,15 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const backToTopBtn = document.getElementById("backToTop");
+
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 100) {
+      backToTopBtn.style.display = "block";
+    } else {
+      backToTopBtn.style.display = "none";
+    }
+  });
+
+  backToTopBtn.addEventListener("click", () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
+});


### PR DESCRIPTION
## Related Issue
Closes #3783

## Summary
This pull request adds a responsive Back-to-Top button to the Carousel Page.  
The motivation is to improve navigation convenience for users scrolling through long content by providing a quick way to return to the top.

## Changes Made
- [x] Added new `carousel.js` file with scroll detection and smooth scroll logic
- [x] Updated `carousel.html` to include the Back-to-Top button element
- [x] Modified `main.css` to style the floating circular button with hover effects
- [ ] Documented usage in relevant markdown/docs

## Technical Details & Scope
- **Component Category:** Button (utility/navigation)
- **Impact Radius:** Carousel Page only; no global assets affected

## Testing & Verification
1. **Local Test Command:** Verified manually in local dev server 
2. **Browsers Checked:** Chrome, Firefox, Edge
3. **Responsive Verification:** Tested layout at 320px (mobile), 768px (tablet), and 1024px (desktop) widths


## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
- [x] Component metadata version and changelog updated if necessary
