### PR TITLE
feat(whiteboard): add undo/redo support with keyboard shortcuts

### DIFF
--- a/whiteboard/wb.css
+++ b/whiteboard/wb.css
@@ -119,6 +119,15 @@ body{
   background: #dc2626;
 }
 
+#undoBtn, #redoBtn {
+  background: #374151;
+  padding: 10px 14px;
+}
+
+#undoBtn:hover, #redoBtn:hover {
+  background: #4b5563;
+}
+
 #saveWrapper {
   position: relative;
   height: 40px;

--- a/whiteboard/wb.html
+++ b/whiteboard/wb.html
@@ -45,6 +45,13 @@
           Clear
         </button>
 
+        <button type="button" id="undoBtn" title="Undo (Ctrl+Z)" aria-label="Undo last action">
+          <i class="fa-solid fa-rotate-left"></i>
+        </button>
+        <button type="button" id="redoBtn" title="Redo (Ctrl+Y)" aria-label="Redo last action">
+          <i class="fa-solid fa-rotate-right"></i>
+        </button>
+
       </div>
 
     </div>

--- a/whiteboard/wb.js
+++ b/whiteboard/wb.js
@@ -6,6 +6,8 @@ const clearBtn = document.getElementById("clearBtn");
 const brushBtn = document.getElementById("brushBtn");
 const eraserBtn = document.getElementById("eraserBtn");
 const fillBtn = document.getElementById("fillBtn");
+const undoBtn = document.getElementById("undoBtn");
+const redoBtn = document.getElementById("redoBtn");
 
 canvas.width = canvas.offsetWidth;
 canvas.height = canvas.offsetHeight;
@@ -13,8 +15,21 @@ canvas.height = canvas.offsetHeight;
 let drawing = false;
 let currentColor = "#000000";
 
+// History for undo/redo
+let history = [];
+let historyIndex = -1;
+
+function saveSnapshot() {
+  // Trim any redo future
+  history = history.slice(0, historyIndex + 1);
+  history.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+  historyIndex++;
+}
+
 ctx.fillStyle = "#ffffff";
 ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+saveSnapshot();
 
 colorPicker.addEventListener("input", e => {
   currentColor = e.target.value;
@@ -24,11 +39,12 @@ colorPicker.addEventListener("input", e => {
 });
 
 canvas.addEventListener("mousedown", () => { drawing = true; });
-canvas.addEventListener("mouseup", () => { drawing = false; ctx.beginPath(); });
+canvas.addEventListener("mouseup", () => { drawing = false; ctx.beginPath(); saveSnapshot(); });
 canvas.addEventListener("mousemove", draw);
 canvas.addEventListener("click", (e) => {
   if (!fillBtn.classList.contains("active")) return;
   floodFill(e.offsetX, e.offsetY, currentColor);
+  saveSnapshot();
 });
 
 function setActiveTool(tool) {
@@ -58,6 +74,7 @@ clearBtn.addEventListener("click", () => {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = "#ffffff";
   ctx.fillRect(0, 0, canvas.width, canvas.height);
+  saveSnapshot();
 });
 
 brushBtn.addEventListener("click", () => {
@@ -73,6 +90,9 @@ eraserBtn.addEventListener("click", () => {
 fillBtn.addEventListener("click", () => {
   setActiveTool(fillBtn);
 });
+
+undoBtn.addEventListener("click", undo);
+redoBtn.addEventListener("click", redo);
 
 let selectedFormat = "png";
 
@@ -130,6 +150,23 @@ function floodFill(startX, startY, fillColor) {
 
   ctx.putImageData(imageData, 0, 0);
 }
+
+function undo() {
+  if (historyIndex <= 0) return;
+  historyIndex--;
+  ctx.putImageData(history[historyIndex], 0, 0);
+}
+
+function redo() {
+  if (historyIndex >= history.length - 1) return;
+  historyIndex++;
+  ctx.putImageData(history[historyIndex], 0, 0);
+}
+
+document.addEventListener("keydown", (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) { e.preventDefault(); undo(); }
+  if ((e.ctrlKey || e.metaKey) && (e.key === "y" || (e.key === "z" && e.shiftKey))) { e.preventDefault(); redo(); }
+});
 
 function injectSaveControls() {
   const toolbar = clearBtn?.parentElement || document.body;


### PR DESCRIPTION
## Related Issue
Closes #3819 

## Summary
Adds undo and redo functionality to the digital whiteboard. Users can now step backward and forward through their drawing history using toolbar buttons or standard keyboard shortcuts.

## Changes Made
- [x] Updated `wb.js` — added history stack, `saveSnapshot()`, `undo()`, `redo()`, keyboard shortcut listener, and button bindings
- [x] Updated `wb.css` — added styles for `#undoBtn` and `#redoBtn`
- [x] Updated `index.html` — added undo and redo buttons to the toolbar

## Technical Details & Scope
- Component Category: Canvas / Whiteboard
- Impact Radius: `wb.js`, `wb.css`, `index.html` — no other pages or global assets touched

## Testing & Verification
Please describe how you verified the changes:
1. **Local Test Command:** `npx serve .`
2. **Browsers Checked:** Google Chrome
3. **Responsive Verification:** Buttons verified at 320px, 768px, 1024px — toolbar wraps correctly on mobile

## Screenshots
<img width="945" height="289" alt="image" src="https://github.com/user-attachments/assets/d2cc6a0a-3b0a-464c-9676-2203fdc356d0" />

## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
- [x] Component metadata version and changelog updated if necessary