### PR TITLE
fix: prevent horizontal overflow of toasts on mobile devices

### DIFF
--- a/toasts.css
+++ b/toasts.css
@@ -888,7 +888,8 @@ padding: 10px 20px;
 
   overflow:hidden;
 
-  min-width:340px;
+  min-width:280px;
+  max-width:calc(100vw - 32px);
 
   padding:18px 20px;
 


### PR DESCRIPTION
# Related Issue
Closes #4054 

# Summary
Adjusted toast elements CSS sizing limits to prevent horizontal page overflow.

# Changes Made
- Modified [toasts.css](file:///c:/Users/babin/Desktop/NSoC_26/UI-Verse/toasts.css).

# Testing
- Confirmed display output in Chrome mobile emulator layouts.

# Impact
Polishes presentation layers.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] Responsive design verified
