### PR TITLE
fix: define missing getNormalizedURL helper in url state manager

### DIFF
--- a/js/features/url-state.js
+++ b/js/features/url-state.js
@@ -24,6 +24,13 @@ const URLStateManager = (function () {
   };
 
   /**
+   * Helper to get a clean URL instance of the current location
+   */
+  function getNormalizedURL() {
+    return new URL(window.location.href);
+  }
+
+  /**
    * Build URL search string from current state
    */
   function buildQueryString(query = '', category = 'all', sort = 'default') {


### PR DESCRIPTION
# Related Issue
Closes #4058 

# Summary
Fixed ReferenceError exception by defining the missing `getNormalizedURL` helper function.

# Changes Made
- Modified [js/features/url-state.js](file:///c:/Users/babin/Desktop/NSoC_26/UI-Verse/js/features/url-state.js).

# Testing
- Ran eslint on the script to confirm zero warnings.
- Tested search filters to verify functional query synchronization.

# Impact
Resolves component search crashes.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
