### PR TITLE
perf: optimize compression ratios in image pipeline

### DIFF
--- a/scripts/image-pipeline.js
+++ b/scripts/image-pipeline.js
@@ -177,7 +177,7 @@ async function createLocalVariants(imagePath, sourceRootPath) {
     await image
       .clone()
       .resize({ width: fallbackWidth, withoutEnlargement: true })
-      .toFormat(fallbackFormat, { quality: 82, effort: 4 })
+      .toFormat(fallbackFormat, { quality: 75, effort: 6 })
       .toFile(fallbackFile);
   }
 
@@ -192,7 +192,7 @@ async function createLocalVariants(imagePath, sourceRootPath) {
       await image
         .clone()
         .resize({ width, withoutEnlargement: true })
-        .avif({ quality: 55 })
+        .avif({ quality: 65, effort: 6 })
         .toFile(avifFile);
     }
 
@@ -200,7 +200,7 @@ async function createLocalVariants(imagePath, sourceRootPath) {
       await image
         .clone()
         .resize({ width, withoutEnlargement: true })
-        .webp({ quality: 80 })
+        .webp({ quality: 75, effort: 6 })
         .toFile(webpFile);
     }
 


### PR DESCRIPTION
# Related Issue
Closes #4063 

# Summary
Tuned AVIF and WebP encoder qualities and effort configurations to reduce bundle weights.

# Changes Made
- Modified [scripts/image-pipeline.js](file:///c:/Users/babin/Desktop/NSoC_26/UI-Verse/scripts/image-pipeline.js).

# Testing
- Tested output file compression sizing difference.
- Verified visual rendering quality.

# Impact
Enhances site load speed.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
