### PR TITLE
refactor: resolve theme initialization fallback in switcher

### DIFF
--- a/components/WebComponents/uv-theme-switcher.js
+++ b/components/WebComponents/uv-theme-switcher.js
@@ -48,7 +48,19 @@ export class UVThemeSwitcher extends HTMLElement {
 
   _getCurrentTheme() {
     if (globalThis.DesignTokens?.getStoredTheme) {
-      return globalThis.DesignTokens.getStoredTheme() || document.documentElement.dataset.theme || 'light';
+      const stored = globalThis.DesignTokens.getStoredTheme();
+      if (stored) return stored;
+    }
+
+    try {
+      const storedTheme = localStorage.getItem('ui-verse-theme') || localStorage.getItem('theme');
+      if (storedTheme) return storedTheme;
+    } catch (e) {}
+
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark';
+      }
     }
 
     return document.documentElement.dataset.theme || 'light';


### PR DESCRIPTION
# Related Issue
Closes #4069 

# Summary
Refactored theme switcher web component initialization logic to resolve theme fallback preferences.

# Changes Made
- Modified [components/WebComponents/uv-theme-switcher.js](file:///c:/Users/babin/Desktop/NSoC_26/UI-Verse/components/WebComponents/uv-theme-switcher.js).

# Testing
- Verified selection synchronization.
- Confirmed correct dark theme initial selection.

# Impact
Improves user theme restoration consistency.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
