### PR TITLE
ci: enforce conventional commits validation on pr commits

### DIFF
--- a/.github/workflows/commitlint-pr.yml
+++ b/.github/workflows/commitlint-pr.yml
@@ -13,6 +13,16 @@ jobs:
     name: Lint PR Title
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint Commits
+        uses: wagoid/commitlint-github-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Validate PR Title
         uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
# Related Issue
Closes #4075 

# Summary
Upgraded the PR commit linting workflow to validate individual commit messages against Conventional Commit rules.

# Changes Made
- Modified [.github/workflows/commitlint-pr.yml](file:///c:/Users/babin/Desktop/NSoC_26/UI-Verse/.github/workflows/commitlint-pr.yml).

# Testing
- Confirmed syntax parses correctly.
- Checked configuration rules against standard CLI linter.

# Impact
Maintains repo log hygiene.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
