### PR TITLE
eat: Smart Component Recommendations Engine — context-aware suggestions (#3758)

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -54,6 +54,14 @@ const Bootstrap = {
       UIverse.register('ComponentIndex', ComponentIndex, dependenciesFor('ComponentIndex'));
     }
 
+    if (typeof ComponentRecommendations !== 'undefined') {
+      UIverse.register('ComponentRecommendations', ComponentRecommendations, dependenciesFor('ComponentRecommendations'));
+    }
+
+    if (typeof RecommendationsUI !== 'undefined') {
+      UIverse.register('RecommendationsUI', RecommendationsUI, dependenciesFor('RecommendationsUI'), { domSelector: 'main.main-home' });
+    }
+
     // Register feature modules (with optional conditional initialization)
     if (typeof Toast !== 'undefined') {
       UIverse.register('Toast', Toast);

--- a/js/core/component-discovery.js
+++ b/js/core/component-discovery.js
@@ -615,6 +615,25 @@
     return _state.items.find((item) => item.id === id) || null;
   }
 
+  function getCategoryItems(category) {
+    const target = String(category || '').toLowerCase().trim();
+    return _state.items.filter((item) => String(item.category || '').toLowerCase().trim() === target);
+  }
+
+  function getCategories() {
+    const cats = new Map();
+    _state.items.forEach((item) => {
+      const cat = String(item.category || 'Component').toLowerCase().trim();
+      if (!cats.has(cat)) {
+        cats.set(cat, { name: item.category || 'Component', count: 0, items: [] });
+      }
+      const bucket = cats.get(cat);
+      bucket.count++;
+      bucket.items.push(item);
+    });
+    return Array.from(cats.entries()).map(([name, data]) => ({ name, ...data }));
+  }
+
   function getFacets() {
     return {
       ..._state.facets,
@@ -666,6 +685,8 @@
     search,
     getAll,
     getById,
+    getCategoryItems,
+    getCategories,
     getFacets,
     getRecentFilters: getRecentFiltersList,
     exportQuery,

--- a/js/features/component-recommendations.js
+++ b/js/features/component-recommendations.js
@@ -1,0 +1,419 @@
+/**
+ * Component Recommendations Engine
+ * Context-aware suggestions based on category relationships, semantic similarity,
+ * session co-view patterns, and metadata overlap.
+ *
+ * Builds on ComponentDiscovery semantic scoring infrastructure.
+ * Zero external ML dependencies — pure metadata + session pattern matching.
+ */
+
+const ComponentRecommendations = (function () {
+  const STORAGE_KEY = 'uiverse_recommendations_dismissed';
+  const SESSION_KEY = 'uiverse_recommendations_session_history';
+  const MAX_SESSION_HISTORY = 20;
+  const DEFAULT_LIMIT = 6;
+
+  // Explicit "pairs well with" category weights
+  const CATEGORY_PAIRINGS = new Map([
+    ['buttons', new Map([['forms', 35], ['inputs', 40], ['cards', 25], ['navigation', 20], ['alerts', 15], ['badges', 15], ['loaders', 10]])],
+    ['inputs', new Map([['forms', 45], ['buttons', 35], ['cards', 20], ['navigation', 15], ['alerts', 10], ['badges', 10]])],
+    ['forms', new Map([['inputs', 45], ['buttons', 35], ['cards', 25], ['alerts', 20], ['navigation', 15], ['badges', 15]])],
+    ['cards', new Map([['buttons', 25], ['forms', 25], ['inputs', 20], ['layout', 30], ['badges', 15], ['alerts', 15], ['pricing', 20]])],
+    ['navigation', new Map([['buttons', 20], ['layout', 35], ['cards', 20], ['forms', 15], ['inputs', 15], ['alerts', 10]])],
+    ['layout', new Map([['navigation', 35], ['cards', 30], ['buttons', 20], ['forms', 15], ['footer', 25], ['hero', 20]])],
+    ['alerts', new Map([['buttons', 15], ['forms', 20], ['inputs', 10], ['cards', 15], ['feedback', 30], ['notifications', 25]])],
+    ['badges', new Map([['buttons', 15], ['cards', 15], ['alerts', 15], ['feedback', 20], ['data-display', 15]])],
+    ['loaders', new Map([['buttons', 10], ['forms', 15], ['cards', 15], ['feedback', 25], ['dashboards', 20]])],
+    ['feedback', new Map([['alerts', 30], ['notifications', 35], ['buttons', 15], ['forms', 15], ['badges', 20]])],
+    ['dashboards', new Map([['charts', 35], ['cards', 30], ['navigation', 25], ['layout', 20], ['tables', 25], ['alerts', 20]])],
+    ['charts', new Map([['dashboards', 35], ['data-display', 30], ['cards', 20], ['tables', 20], ['layout', 15]])],
+    ['tables', new Map([['data-display', 30], ['dashboards', 25], ['forms', 20], ['inputs', 20], ['cards', 15], ['pagination', 25]])],
+    ['pricing', new Map([['cards', 20], ['buttons', 15], ['forms', 15], ['commerce', 30], ['testimonials', 20]])],
+    ['testimonials', new Map([['cards', 25], ['pricing', 20], ['commerce', 20], ['layout', 15], ['gallery', 15]])],
+    ['gallery', new Map([['layout', 25], ['cards', 20], ['images', 20], ['carousel', 25], ['lightbox', 15]])],
+    ['authentication', new Map([['forms', 35], ['inputs', 30], ['buttons', 25], ['cards', 20], ['alerts', 15], ['navigation', 10]])],
+    ['commerce', new Map([['pricing', 30], ['cards', 25], ['buttons', 20], ['forms', 20], ['inputs', 15], ['gallery', 15]])],
+    ['data-display', new Map([['dashboards', 25], ['charts', 30], ['tables', 25], ['cards', 15], ['forms', 15]])],
+    ['footer', new Map([['layout', 30], ['navigation', 25], ['cards', 15], ['forms', 10]])],
+    ['hero', new Map([['layout', 30], ['buttons', 20], ['navigation', 20], ['cards', 15]])],
+    ['tabs', new Map([['navigation', 35], ['cards', 20], ['buttons', 15], ['forms', 15]])],
+    ['popover', new Map([['buttons', 20], ['cards', 20], ['alerts', 15], ['tooltips', 25]])],
+    ['tooltip', new Map([['buttons', 20], ['forms', 15], ['inputs', 15], ['cards', 15]])],
+    ['modal', new Map([['buttons', 25], ['forms', 20], ['alerts', 15], ['cards', 15]])],
+    ['calendar', new Map([['data-display', 30], ['forms', 25], ['inputs', 20], ['dashboards', 15]])],
+    ['checkbox', new Map([['forms', 40], ['inputs', 35], ['buttons', 20], ['radio', 25]])],
+    ['radio', new Map([['forms', 40], ['inputs', 35], ['checkbox', 25], ['buttons', 20]])],
+    ['switch', new Map([['forms', 35], ['inputs', 30], ['buttons', 20], ['settings', 20]])],
+    ['slider', new Map([['forms', 30], ['inputs', 25], ['charts', 20], ['dashboards', 15]])],
+    ['progress', new Map([['loaders', 30], ['dashboards', 25], ['forms', 15], ['cards', 15]])],
+    ['stepper', new Map([['forms', 35], ['buttons', 25], ['navigation', 20], ['progress', 20]])],
+    ['breadcrumb', new Map([['navigation', 35], ['cards', 15], ['layout', 20], ['buttons', 10]])],
+    ['pagination', new Map([['tables', 30], ['data-display', 25], ['navigation', 20], ['cards', 15]])],
+    ['avatar', new Map([['cards', 25], ['profile', 30], ['navigation', 15], ['buttons', 10]])],
+    ['chip', new Map([['buttons', 20], ['forms', 20], ['cards', 15], ['tags', 25]])],
+    ['tag', new Map([['cards', 20], ['buttons', 15], ['forms', 15], ['chip', 25]])],
+    ['divider', new Map([['layout', 30], ['cards', 15], ['forms', 15], ['navigation', 10]])],
+    ['skeleton', new Map([['loaders', 30], ['cards', 20], ['dashboards', 20], ['tables', 15]])],
+    ['empty-state', new Map([['cards', 25], ['buttons', 20], ['illustration', 15], ['layout', 15]])],
+    ['timeline', new Map([['data-display', 30], ['cards', 20], ['dashboards', 20], ['history', 15]])],
+    ['tree', new Map([['navigation', 30], ['sidebar', 25], ['data-display', 20], ['files', 15]])],
+    ['drawer', new Map([['navigation', 30], ['layout', 25], ['sidebar', 25], ['modal', 15]])],
+    ['app-bar', new Map([['navigation', 30], ['layout', 25], ['buttons', 15], ['search', 15]])],
+    ['bottom-nav', new Map([['navigation', 30], ['layout', 25], ['buttons', 15], ['app-bar', 20]])],
+    ['speed-dial', new Map([['buttons', 30], ['navigation', 20], ['floating-action', 25], ['cards', 10]])],
+    ['snackbar', new Map([['feedback', 30], ['alerts', 25], ['buttons', 15], ['toast', 20]])],
+    ['toast', new Map([['feedback', 30], ['alerts', 25], ['buttons', 15], ['snackbar', 20]])]
+  ]);
+
+  const TAG_OVERLAP_WEIGHT = 12;
+  const SEMANTIC_OVERLAP_WEIGHT = 18;
+  const POPULARITY_BOOST = 8;
+  const SESSION_COVIEW_WEIGHT = 25;
+
+  function safeStorage() {
+    try {
+      return window.localStorage;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function readJson(text, fallback) {
+    try {
+      return JSON.parse(text);
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function getDismissed() {
+    const storage = safeStorage();
+    if (!storage) return new Set();
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      const parsed = raw ? readJson(raw, []) : [];
+      return new Set(parsed);
+    } catch (_) {
+      return new Set();
+    }
+  }
+
+  function saveDismissed(ids) {
+    const storage = safeStorage();
+    if (!storage) return;
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(Array.from(ids)));
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  function getSessionHistory() {
+    try {
+      const raw = sessionStorage.getItem(SESSION_KEY);
+      return raw ? readJson(raw, []) : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  function saveSessionHistory(history) {
+    try {
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(history.slice(-MAX_SESSION_HISTORY)));
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  function recordPageView(categoryId) {
+    const history = getSessionHistory();
+    const now = Date.now();
+    if (history.length > 0 && history[history.length - 1].category === categoryId) {
+      history[history.length - 1].at = now;
+    } else {
+      history.push({ category: categoryId, at: now });
+    }
+    saveSessionHistory(history);
+  }
+
+  function getCoViewBoost(sourceCategory) {
+    const history = getSessionHistory();
+    if (history.length < 2) return new Map();
+
+    const boosts = new Map();
+    history.forEach((entry, idx) => {
+      if (entry.category === sourceCategory) return;
+      const windowStart = Math.max(0, idx - 3);
+      const windowEnd = Math.min(history.length, idx + 4);
+      for (let i = windowStart; i < windowEnd; i++) {
+        if (i === idx) continue;
+        if (history[i].category === sourceCategory) {
+          boosts.set(entry.category, (boosts.get(entry.category) || 0) + 1);
+        }
+      }
+    });
+
+    return boosts;
+  }
+
+  function normalizeCategory(cat) {
+    return String(cat || '').toLowerCase().trim();
+  }
+
+  function ensureDiscovery() {
+    let disc = window.ComponentDiscovery || window.ComponentIndex;
+    if (!disc && typeof require === 'function') {
+      try {
+        disc = require('../core/component-discovery.js');
+      } catch (_) {
+        try {
+          disc = require('../core/component-index.js');
+        } catch (__) {
+          disc = null;
+        }
+      }
+    }
+    return disc;
+  }
+
+  function ensureDiscoveryInitialized() {
+    const disc = ensureDiscovery();
+    if (!disc) return null;
+
+    // If discovery has no items, try to initialize from global data
+    if (!disc._state || !disc._state.initialized || disc._state.items.length === 0) {
+      if (typeof disc.init === 'function' && window.UIVerseComponentsIndexData) {
+        try {
+          const catalog = window.UIVerseComponentsIndexData;
+          if (catalog && Array.isArray(catalog.categories)) {
+            const items = [];
+            catalog.categories.forEach((cat) => {
+              (cat.items || []).forEach((item) => {
+                items.push({
+                  id: item.id,
+                  title: item.title,
+                  path: item.path,
+                  category: cat.id || cat.name,
+                  categoryId: cat.id,
+                  popularity: item.popularity || 0,
+                  tags: item.tags || [],
+                  description: item.description || '',
+                  aliases: item.aliases || [],
+                  searchTokens: []
+                });
+              });
+            });
+            disc.init({ items });
+          }
+        } catch (e) {
+          if (window.UIVERSE_DEBUG) {
+            console.warn('[Recommendations] Failed to init discovery from global data:', e);
+          }
+        }
+      }
+    }
+
+    return disc;
+  }
+
+  function getAllItems() {
+    const disc = ensureDiscoveryInitialized();
+    if (!disc) return [];
+    if (typeof disc.getAll === 'function') {
+      return disc.getAll();
+    }
+    if (disc._state && Array.isArray(disc._state.items)) {
+      return disc._state.items;
+    }
+    return [];
+  }
+
+  function getCategoryItems(categoryId) {
+    const target = normalizeCategory(categoryId);
+    return getAllItems().filter((item) => normalizeCategory(item.category) === target);
+  }
+
+  function getCategoryTags(categoryId) {
+    const items = getCategoryItems(categoryId);
+    const tagCounts = new Map();
+    items.forEach((item) => {
+      (item.tags || []).forEach((tag) => {
+        tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+      });
+    });
+    return tagCounts;
+  }
+
+  function scoreRelatedCategory(sourceId, targetId) {
+    const source = normalizeCategory(sourceId);
+    const target = normalizeCategory(targetId);
+    if (source === target) return { score: 0, reasons: [] };
+
+    let score = 0;
+    const reasons = [];
+
+    // 1. Explicit pairing weight
+    const pairings = CATEGORY_PAIRINGS.get(source);
+    if (pairings && pairings.has(target)) {
+      const w = pairings.get(target);
+      score += w;
+      reasons.push(`pairing:${w}`);
+    }
+
+    // 2. Tag overlap between categories
+    const sourceTags = getCategoryTags(source);
+    const targetTags = getCategoryTags(target);
+    if (sourceTags.size > 0 && targetTags.size > 0) {
+      let overlap = 0;
+      sourceTags.forEach((count, tag) => {
+        if (targetTags.has(tag)) overlap += Math.min(count, targetTags.get(tag));
+      });
+      if (overlap > 0) {
+        const overlapScore = Math.min(SEMANTIC_OVERLAP_WEIGHT, overlap * TAG_OVERLAP_WEIGHT);
+        score += overlapScore;
+        reasons.push(`tag-overlap:${overlapScore}`);
+      }
+    }
+
+    // 3. Session co-view boost
+    const coViewBoosts = getCoViewBoost(source);
+    if (coViewBoosts.has(target)) {
+      const boost = Math.min(SESSION_COVIEW_WEIGHT, coViewBoosts.get(target) * 8);
+      score += boost;
+      reasons.push(`session:${boost}`);
+    }
+
+    // 4. Semantic token overlap via discovery engine
+    const disc = ensureDiscoveryInitialized();
+    if (disc && disc._state && disc._state.items) {
+      const sourceItems = getCategoryItems(source);
+      const targetItems = getCategoryItems(target);
+      const sourceTokens = new Set();
+      const targetTokens = new Set();
+
+      sourceItems.forEach((item) => {
+        (item.searchTokens || []).forEach((t) => sourceTokens.add(t));
+      });
+      targetItems.forEach((item) => {
+        (item.searchTokens || []).forEach((t) => targetTokens.add(t));
+      });
+
+      let semanticOverlap = 0;
+      sourceTokens.forEach((t) => {
+        if (targetTokens.has(t)) semanticOverlap++;
+      });
+      if (semanticOverlap > 0) {
+        const semScore = Math.min(20, semanticOverlap * 2);
+        score += semScore;
+        reasons.push(`semantic:${semScore}`);
+      }
+    }
+
+    return { score, reasons };
+  }
+
+  function getForCategory(categoryId, options = {}) {
+    const source = normalizeCategory(categoryId);
+    const limit = typeof options.limit === 'number' ? options.limit : DEFAULT_LIMIT;
+    const excludeDismissed = options.excludeDismissed !== false;
+    const dismissed = excludeDismissed ? getDismissed() : new Set();
+    const allItems = getAllItems();
+
+    // Gather all distinct categories present in the catalog
+    const categories = new Map();
+    allItems.forEach((item) => {
+      const cat = normalizeCategory(item.category);
+      if (!cat || cat === source) return;
+      if (!categories.has(cat)) {
+        categories.set(cat, { category: cat, items: [], maxPopularity: 0 });
+      }
+      const bucket = categories.get(cat);
+      bucket.items.push(item);
+      bucket.maxPopularity = Math.max(bucket.maxPopularity, item.popularity || item.documentationScore || 0);
+    });
+
+    // Score each category
+    const scored = [];
+    categories.forEach((bucket, cat) => {
+      const ranking = scoreRelatedCategory(source, cat);
+      const popBoost = Math.min(POPULARITY_BOOST, Math.round((bucket.maxPopularity / 100) * POPULARITY_BOOST));
+      const totalScore = ranking.score + popBoost;
+
+      const rep = bucket.items
+        .filter((item) => !dismissed.has(item.id))
+        .sort((a, b) => (b.popularity || b.documentationScore || 0) - (a.popularity || a.documentationScore || 0))[0];
+
+      if (!rep) return;
+
+      scored.push({
+        category: cat,
+        score: totalScore,
+        confidence: Math.min(100, Math.round(totalScore * 1.2)),
+        reasons: ranking.reasons.concat(`popularity:${popBoost}`),
+        representative: rep,
+        itemCount: bucket.items.length
+      });
+    });
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit);
+  }
+
+  function getForComponent(componentId, options = {}) {
+    const allItems = getAllItems();
+    const sourceItem = allItems.find((item) => item.id === componentId);
+    if (!sourceItem) return getForCategory('other', options);
+    const category = normalizeCategory(sourceItem.category);
+    return getForCategory(category, options);
+  }
+
+  function dismiss(id) {
+    const dismissed = getDismissed();
+    dismissed.add(id);
+    saveDismissed(dismissed);
+  }
+
+  function restoreDismissed(id) {
+    const dismissed = getDismissed();
+    dismissed.delete(id);
+    saveDismissed(dismissed);
+  }
+
+  function clearSession() {
+    try {
+      sessionStorage.removeItem(SESSION_KEY);
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  function clearAllDismissed() {
+    const storage = safeStorage();
+    if (storage) {
+      try {
+        storage.removeItem(STORAGE_KEY);
+      } catch (_) {
+        // ignore
+      }
+    }
+  }
+
+  return {
+    getForCategory,
+    getForComponent,
+    dismiss,
+    restoreDismissed,
+    recordPageView,
+    clearSession,
+    clearAllDismissed,
+    _getSessionHistory: getSessionHistory,
+    _getDismissed: getDismissed,
+    _ensureDiscoveryInitialized: ensureDiscoveryInitialized
+  };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ComponentRecommendations;
+}
+
+window.ComponentRecommendations = ComponentRecommendations;

--- a/js/features/recommendations-ui.js
+++ b/js/features/recommendations-ui.js
@@ -1,0 +1,499 @@
+/**
+ * Recommendations UI Panel
+ * Injects "You might also like" panel into component category pages.
+ * Hooks into loader lifecycle, refreshes per navigation (full page reload).
+ */
+
+const RecommendationsUI = (function () {
+  const PANEL_ID = 'component-recommendations-panel';
+  const CONTAINER_SELECTOR = 'main.main-home';
+  const FALLBACK_SELECTOR = 'body';
+  const MAX_ITEMS = 6;
+  const DEV_MODE = location.search.includes('rec-debug=1');
+
+  function ensureStyles() {
+    if (document.getElementById('recommendations-panel-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'recommendations-panel-styles';
+    style.textContent = `
+      .rec-panel {
+        margin: 32px 24px 48px;
+        padding: 24px;
+        border-radius: 16px;
+        background: linear-gradient(135deg, rgba(123,97,255,0.06), rgba(235,104,53,0.04));
+        border: 1px solid rgba(123,97,255,0.12);
+        position: relative;
+      }
+      .rec-panel-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 20px;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+      .rec-panel-title {
+        font-family: 'Syne', sans-serif;
+        font-weight: 700;
+        font-size: 18px;
+        color: var(--text-primary, #1a1a2e);
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin: 0;
+      }
+      .rec-panel-title i {
+        color: #7b61ff;
+        font-size: 16px;
+      }
+      .rec-panel-sub {
+        font-size: 13px;
+        color: var(--text-secondary, #666);
+        margin: 4px 0 0;
+      }
+      .rec-panel-actions {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .rec-panel-debug {
+        font-size: 11px;
+        font-family: monospace;
+        color: #7b61ff;
+        background: rgba(123,97,255,0.08);
+        padding: 2px 8px;
+        border-radius: 6px;
+        display: none;
+      }
+      .rec-panel-debug.visible {
+        display: inline-block;
+      }
+      .rec-dismiss-btn {
+        background: none;
+        border: none;
+        color: var(--text-secondary, #999);
+        cursor: pointer;
+        font-size: 13px;
+        padding: 4px 8px;
+        border-radius: 6px;
+        transition: 0.2s;
+      }
+      .rec-dismiss-btn:hover {
+        background: rgba(0,0,0,0.06);
+        color: #d63031;
+      }
+      .rec-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: 16px;
+      }
+      .rec-card {
+        background: var(--card-bg, #fff);
+        border: 1px solid var(--card-border, rgba(0,0,0,0.06));
+        border-radius: 12px;
+        padding: 16px;
+        cursor: pointer;
+        transition: transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+        text-decoration: none;
+        color: inherit;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        position: relative;
+      }
+      .rec-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 24px rgba(123,97,255,0.12);
+        border-color: rgba(123,97,255,0.25);
+      }
+      .rec-card-top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .rec-card-category {
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: #7b61ff;
+        background: rgba(123,97,255,0.08);
+        padding: 3px 8px;
+        border-radius: 6px;
+      }
+      .rec-card-confidence {
+        font-size: 10px;
+        font-family: monospace;
+        color: #999;
+        display: none;
+      }
+      .rec-card-confidence.visible {
+        display: block;
+      }
+      .rec-card-title {
+        font-weight: 600;
+        font-size: 15px;
+        color: var(--text-primary, #1a1a2e);
+        margin: 0;
+        line-height: 1.3;
+      }
+      .rec-card-desc {
+        font-size: 13px;
+        color: var(--text-secondary, #666);
+        line-height: 1.4;
+        margin: 0;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .rec-card-meta {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 12px;
+        color: var(--text-muted, #aaa);
+        margin-top: auto;
+        padding-top: 8px;
+        border-top: 1px solid var(--card-border, rgba(0,0,0,0.04));
+      }
+      .rec-card-meta i {
+        font-size: 11px;
+      }
+      .rec-empty {
+        font-size: 14px;
+        color: var(--text-secondary, #888);
+        padding: 12px 0;
+      }
+      .rec-toast {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        background: #111;
+        color: #fff;
+        padding: 10px 14px;
+        border-radius: 8px;
+        font-size: 14px;
+        z-index: 9999;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+        animation: recFadeIn 0.3s ease;
+      }
+      @keyframes recFadeIn {
+        from { opacity: 0; transform: translateY(10px); }
+        to { opacity: 1; transform: translateY(0); }
+      }
+      body.dark-mode .rec-panel {
+        background: linear-gradient(135deg, rgba(123,97,255,0.1), rgba(235,104,53,0.06));
+        border-color: rgba(123,97,255,0.2);
+      }
+      body.dark-mode .rec-card {
+        background: var(--card-bg-dark, #1e1e2f);
+        border-color: var(--card-border-dark, rgba(255,255,255,0.06));
+      }
+      body.dark-mode .rec-card-title {
+        color: var(--text-primary-dark, #f0f0f5);
+      }
+      body.dark-mode .rec-card-desc {
+        color: var(--text-secondary-dark, #aaa);
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function showToast(message) {
+    const existing = document.querySelector('.rec-toast');
+    if (existing) existing.remove();
+    const toast = document.createElement('div');
+    toast.className = 'rec-toast';
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 1500);
+  }
+
+  function inferCategoryFromPage() {
+    const page = (location.pathname.split('/').pop() || 'index.html').toLowerCase();
+    const map = {
+      'button.html': 'buttons',
+      'buttons.html': 'buttons',
+      'inputs.html': 'forms',
+      'forms.html': 'forms',
+      'cards.html': 'cards',
+      'navbar.html': 'navigation',
+      'navigation.html': 'navigation',
+      'badges.html': 'data-display',
+      'alerts.html': 'feedback',
+      'notifications-premium.html': 'feedback',
+      'notifications.html': 'feedback',
+      'dashboard.html': 'dashboards',
+      'charts.html': 'data-display',
+      'table.html': 'data-display',
+      'tables.html': 'data-display',
+      'pricing.html': 'commerce',
+      'ecommerce.html': 'commerce',
+      'testimonials.html': 'other',
+      'gallery.html': 'layout',
+      'hero.html': 'layout',
+      'footer.html': 'layout',
+      'loaders.html': 'other',
+      'loader.html': 'other',
+      'timeline.html': 'data-display',
+      'map.html': 'data-display',
+      'menu.html': 'navigation',
+      'tabs.html': 'navigation',
+      'auth.html': 'authentication',
+      'checkbox.html': 'forms',
+      'radiobutton.html': 'buttons',
+      'switches.html': 'buttons',
+      'toggles.html': 'buttons',
+      'color.html': 'other',
+      'div.html': 'other',
+      'hover.html': 'other',
+      'search.html': 'other',
+      'widgets.html': 'other',
+      'error.html': 'other',
+      'article.html': 'other',
+      'blog.html': 'other',
+      'about.html': 'other',
+      'faq.html': 'other',
+      'documentation.html': 'other',
+      'contact.html': 'other',
+      'terms.html': 'other',
+      'license.html': 'other',
+      'privacy.html': 'other',
+      'settings.html': 'other',
+      'favorites.html': 'other',
+      'mycollection.html': 'other',
+      'profile-components.html': 'other',
+      'dropdown-components.html': 'navigation',
+      'calendar.html': 'data-display',
+      'calendarcomponent.html': 'data-display',
+      'calendar-components.html': 'data-display',
+      'notes-components.html': 'data-display',
+      'leaderboard-components.html': 'data-display',
+      'breadcrumbs.html': 'data-display',
+      'empty-state.html': 'other',
+      'url-state.html': 'other',
+      'test-url-state.html': 'other',
+      'test-command-palette.html': 'other',
+      'test-security-csp.html': 'other',
+      'step-indicators.html': 'other',
+      'progress-premium.html': 'other',
+      'ratings-premium.html': 'other',
+      'filters-premium.html': 'other',
+      'admin-panel.html': 'dashboards',
+      'flipcards.html': 'cards',
+      'ui-cards.html': 'cards',
+      'popover.html': 'feedback',
+      'popovers.html': 'feedback',
+      'snackbar.html': 'feedback',
+      'toasts.html': 'feedback',
+      'toast.html': 'feedback',
+      'tooltip.html': 'other',
+      'spotlightui.html': 'other',
+      'retroui.html': 'other',
+      'kanbanui.html': 'other',
+      'chatui.html': 'other',
+      'musicicon.html': 'other',
+      'command-palette.html': 'other',
+      'compare.html': 'other',
+      'sandbox.html': 'other',
+      'playground.html': 'other',
+      'welcome.html': 'other',
+      'index.html': null // home page — skip
+    };
+    return map[page] || null;
+  }
+
+  function buildPanel(recommendations) {
+    const panel = document.createElement('div');
+    panel.id = PANEL_ID;
+    panel.className = 'rec-panel';
+
+    const header = document.createElement('div');
+    header.className = 'rec-panel-header';
+
+    const titleBlock = document.createElement('div');
+    const title = document.createElement('h3');
+    title.className = 'rec-panel-title';
+    title.innerHTML = '<i class="fa-solid fa-wand-magic-sparkles"></i> You might also like';
+    const sub = document.createElement('p');
+    sub.className = 'rec-panel-sub';
+    sub.textContent = 'Complementary components based on category relationships and usage patterns';
+    titleBlock.appendChild(title);
+    titleBlock.appendChild(sub);
+
+    const actions = document.createElement('div');
+    actions.className = 'rec-panel-actions';
+
+    if (DEV_MODE) {
+      const debug = document.createElement('span');
+      debug.className = 'rec-panel-debug visible';
+      debug.textContent = 'dev';
+      actions.appendChild(debug);
+    }
+
+    const clearBtn = document.createElement('button');
+    clearBtn.className = 'rec-dismiss-btn';
+    clearBtn.innerHTML = '<i class="fa-solid fa-rotate-right"></i> Reset';
+    clearBtn.title = 'Restore all dismissed recommendations';
+    clearBtn.addEventListener('click', () => {
+      ComponentRecommendations.clearAllDismissed();
+      render();
+      showToast('Recommendations restored');
+    });
+    actions.appendChild(clearBtn);
+
+    header.appendChild(titleBlock);
+    header.appendChild(actions);
+
+    const grid = document.createElement('div');
+    grid.className = 'rec-grid';
+
+    if (!recommendations || recommendations.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'rec-empty';
+      empty.textContent = 'No recommendations available for this category yet.';
+      grid.appendChild(empty);
+    } else {
+      recommendations.forEach((rec) => {
+        const item = rec.representative;
+        if (!item) return;
+
+        const card = document.createElement('a');
+        card.className = 'rec-card';
+        card.href = item.path || '#';
+        card.setAttribute('data-rec-id', item.id);
+        card.setAttribute('data-rec-category', rec.category);
+
+        const top = document.createElement('div');
+        top.className = 'rec-card-top';
+
+        const catLabel = document.createElement('span');
+        catLabel.className = 'rec-card-category';
+        catLabel.textContent = rec.category;
+
+        const conf = document.createElement('span');
+        conf.className = 'rec-card-confidence' + (DEV_MODE ? ' visible' : '');
+        conf.textContent = rec.confidence + '%';
+
+        top.appendChild(catLabel);
+        top.appendChild(conf);
+
+        const t = document.createElement('h4');
+        t.className = 'rec-card-title';
+        t.textContent = item.title || item.id;
+
+        const desc = document.createElement('p');
+        desc.className = 'rec-card-desc';
+        desc.textContent = item.description || `Explore ${rec.itemCount} ${rec.category} components`;
+
+        const meta = document.createElement('div');
+        meta.className = 'rec-card-meta';
+        meta.innerHTML = `<span><i class="fa-solid fa-layer-group"></i> ${rec.itemCount} items</span>`;
+
+        const dismissBtn = document.createElement('button');
+        dismissBtn.className = 'rec-dismiss-btn';
+        dismissBtn.innerHTML = '<i class="fa-solid fa-xmark"></i>';
+        dismissBtn.title = 'Dismiss this recommendation';
+        dismissBtn.style.marginLeft = 'auto';
+        dismissBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          ComponentRecommendations.dismiss(item.id);
+          card.style.opacity = '0';
+          card.style.transform = 'scale(0.95)';
+          setTimeout(() => {
+            card.remove();
+            if (grid.children.length === 0) {
+              render();
+            }
+          }, 200);
+          showToast('Dismissed. Reset to restore.');
+        });
+
+        meta.appendChild(dismissBtn);
+
+        card.appendChild(top);
+        card.appendChild(t);
+        card.appendChild(desc);
+        card.appendChild(meta);
+
+        grid.appendChild(card);
+      });
+    }
+
+    panel.appendChild(header);
+    panel.appendChild(grid);
+    return panel;
+  }
+
+  function findInsertPoint() {
+    const main = document.querySelector(CONTAINER_SELECTOR);
+    if (!main) return document.querySelector(FALLBACK_SELECTOR);
+
+    const grid = main.querySelector('.button-grid, .card-grid, .component-grid, .features, [class*="grid"]');
+    if (grid && grid.parentNode === main) {
+      return grid;
+    }
+
+    const footer = main.querySelector('footer, .footer');
+    if (footer) return footer;
+
+    return main.lastElementChild;
+  }
+
+  function removeExisting() {
+    const existing = document.getElementById(PANEL_ID);
+    if (existing) existing.remove();
+  }
+
+  function render() {
+    const engine = window.ComponentRecommendations;
+    if (!engine) {
+      console.warn('RecommendationsUI: ComponentRecommendations not loaded');
+      return;
+    }
+
+    const category = inferCategoryFromPage();
+    if (!category) {
+      return;
+    }
+
+    engine.recordPageView(category);
+
+    const recs = engine.getForCategory(category, { limit: MAX_ITEMS });
+    if (!recs.length) return;
+
+    ensureStyles();
+    removeExisting();
+
+    const panel = buildPanel(recs);
+    const insertAfter = findInsertPoint();
+    if (insertAfter && insertAfter.parentNode) {
+      insertAfter.parentNode.insertBefore(panel, insertAfter.nextSibling);
+    } else {
+      const main = document.querySelector(CONTAINER_SELECTOR) || document.body;
+      main.appendChild(panel);
+    }
+  }
+
+  function init() {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', render);
+    } else {
+      render();
+    }
+  }
+
+  return {
+    init,
+    render,
+    inferCategoryFromPage
+  };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = RecommendationsUI;
+}
+
+window.RecommendationsUI = RecommendationsUI;

--- a/js/loader.js
+++ b/js/loader.js
@@ -33,10 +33,10 @@
   // Per-page overrides (only load what's necessary)
   const pageMap = {
     'index.html': defaultFeatures,
-    'button.html': ['js/features/toast.js','js/features/code-tools.js','js/features/sidebar.js','js/features/theme.js','js/features/scroll.js','js/features/search.js','js/features/command-palette.js','js/features/url-state.js','js/features/url-state-integration.js'],
-    'cards.html': ['js/features/toast.js','js/features/code-tools.js','js/features/sidebar.js','js/features/search.js','js/features/theme.js','js/features/scroll.js','js/features/sandbox.js','js/features/command-palette.js'],
-    'badges.html': ['js/features/toast.js','js/features/sidebar.js','js/features/command-palette.js'],
-    'forms.html': ['js/features/toast.js','js/features/alerts.js','js/features/sidebar.js','js/features/command-palette.js']
+    'button.html': ['js/features/toast.js','js/features/code-tools.js','js/features/sidebar.js','js/features/theme.js','js/features/scroll.js','js/features/search.js','js/features/command-palette.js','js/features/url-state.js','js/features/url-state-integration.js','js/features/component-recommendations.js','js/features/recommendations-ui.js'],
+    'cards.html': ['js/features/toast.js','js/features/code-tools.js','js/features/sidebar.js','js/features/search.js','js/features/theme.js','js/features/scroll.js','js/features/sandbox.js','js/features/command-palette.js','js/features/component-recommendations.js','js/features/recommendations-ui.js'],
+    'badges.html': ['js/features/toast.js','js/features/sidebar.js','js/features/command-palette.js','js/features/component-recommendations.js','js/features/recommendations-ui.js'],
+    'forms.html': ['js/features/toast.js','js/features/alerts.js','js/features/sidebar.js','js/features/command-palette.js','js/features/component-recommendations.js','js/features/recommendations-ui.js']
   };
 
   const scriptsToLoad = [];


### PR DESCRIPTION
Closes #3758

## Problem
Developers browsing component categories (e.g., Buttons) had no way to discover complementary components (Inputs, Forms, Cards) without manual navigation. Discovery did not scale as the library grew.

## Solution
Introduced a two-layer recommendation system: engine + UI panel.

## Changes by file

| File | Change |
|------|--------|
| `js/features/component-recommendations.js` | **New**: Pure metadata/session engine. Scores related categories via explicit pairings, tag overlap, semantic token overlap (via `ComponentDiscovery`), and session co-view patterns. Self-initializes `ComponentDiscovery` from `UIVerseComponentsIndexData` if needed. |
| `js/features/recommendations-ui.js` | **New**: Panel renderer. Injects "You might also like" below component grids. Dismissible per-card with `localStorage` persistence. Reset button restores all. Confidence % badges in `?rec-debug=1` mode. Dark mode support. |
| `js/loader.js` | Added engine + UI scripts to `button.html`, `cards.html`, `badges.html`, `forms.html` page maps. |
| `js/bootstrap.js` | Registered `ComponentRecommendations` and `RecommendationsUI` with `UIverse` registry. `RecommendationsUI` uses `domSelector: 'main.main-home'` guard. |
| `js/core/component-discovery.js` | Added `getCategoryItems()` and `getCategories()` exports for category-scoped queries. |

## Technical Notes

- **Zero external ML dependencies**: all scoring is deterministic metadata + session pattern matching
- **Builds on existing infrastructure**: reuses `ComponentDiscovery` semantic groups and `UIVerseComponentsIndexData` catalog
- **Session-aware**: `sessionStorage` tracks category view history; co-viewed categories get up to 25pt boost
- **Dismissible + persistable**: `localStorage` stores dismissed IDs; "Reset" button clears all
- **Confidence scores**: normalized 0-100, visible to maintainers via `?rec-debug=1`
- **Self-contained styles**: inline `&lt;style&gt;` injection avoids touching `shared-page.css`
- **Defensive initialization**: engine lazy-inits `ComponentDiscovery` if not already populated
- **Dark mode**: CSS variable fallbacks + `body.dark-mode` selectors adapt automatically

## Verification

1. Open `button.html` → scroll below grid → "You might also like" panel appears
2. Cards show cross-category suggestions (Forms, Inputs, Cards, Navigation)
3. Click × → reload → card stays hidden
4. Click "Reset" → all cards reappear
5. Append `?rec-debug=1` → confidence % visible on each card
6. Toggle dark mode → panel styling adapts
7. Navigate Buttons → Forms → Buttons → Forms recommendations strengthen for Buttons