### PR TITLE
feat: add standardized component metadata schema

### DIFF
--- a/COMPONENT_SCHEMA.md
+++ b/COMPONENT_SCHEMA.md
@@ -1,0 +1,252 @@
+# Component Metadata Schema Documentation
+
+## Overview
+
+This document defines the standardized metadata schema for UIverse components. This schema enables consistent component documentation, backend integration, and programmatic component discovery.
+
+## Files
+
+### 1. `components.json`
+Centralized metadata registry for all UI components with detailed information about each component.
+
+**Top-level structure:**
+- `version`: Schema version (e.g., "2.0.0")
+- `lastUpdated`: ISO date of last update
+- `totalComponents`: Total count of components across all categories
+- `categories`: Array of component categories
+- `sharedUtilities`: Reusable CSS and JavaScript utilities
+- `themes`: Available theme configurations
+- `accessibility`: Accessibility compliance information
+- `metadata`: Project-level metadata
+
+### 2. `registry.json`
+High-level registry for component organization, pagination, and build dependencies.
+
+**Top-level structure:**
+- `componentRegistry`: Organized components by category with file mappings
+- `pagination`: Pagination information for component listing
+- `dependencies`: Shared utilities and file relationships
+- `fileMapping`: Map of HTML files to their metadata
+- `buildInfo`: Framework and build tool information
+
+## Component Object Schema
+
+### Full Component Definition (from `components.json`)
+
+```json
+{
+  "id": "unique-identifier",
+  "name": "Component Name",
+  "description": "Short description of the component",
+  "file": "component-page.html",
+  "tags": ["tag1", "tag2"],
+  "dependencies": ["style.css", "script.js"],
+  "sharedUtilities": ["utility-name"],
+  "difficulty": "beginner|intermediate|advanced",
+  "responsive": true,
+  "darkModeSupport": true
+}
+```
+
+### Field Descriptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier (kebab-case) |
+| `name` | string | Human-readable component name |
+| `description` | string | Short description (1-2 sentences) |
+| `file` | string | HTML file containing the component |
+| `tags` | array | Search and categorization tags |
+| `dependencies` | array | Required CSS/JS files |
+| `sharedUtilities` | array | Reference to shared utility names |
+| `difficulty` | enum | beginner, intermediate, or advanced |
+| `responsive` | boolean | Whether component is responsive |
+| `darkModeSupport` | boolean | Whether component supports dark mode |
+
+## Category Object Schema
+
+```json
+{
+  "id": "category-id",
+  "name": "Category Name",
+  "icon": "emoji",
+  "description": "Category description",
+  "count": 24,
+  "components": [
+    { /* component objects */ }
+  ]
+}
+```
+
+## Shared Utilities Schema
+
+### CSS Utilities
+
+```json
+{
+  "name": "utility-name",
+  "file": "style.css",
+  "description": "What this utility does"
+}
+```
+
+### JavaScript Utilities
+
+```json
+{
+  "name": "utility-name",
+  "file": "script.js",
+  "description": "What this utility does"
+}
+```
+
+## Registry Entry Schema (from `registry.json`)
+
+```json
+{
+  "category": "buttons",
+  "pageFile": "button.html",
+  "count": 24,
+  "cssFiles": ["buttons.css", "style.css"],
+  "jsFiles": ["script.js"],
+  "components": ["component-id-1", "component-id-2"]
+}
+```
+
+## Usage Examples
+
+### Querying All Buttons
+
+```javascript
+const components = require('./components.json');
+const buttons = components.categories.find(cat => cat.id === 'buttons');
+console.log(`Total buttons: ${buttons.count}`);
+```
+
+### Finding Component Dependencies
+
+```javascript
+const registry = require('./registry.json');
+const buttonRegistry = registry.componentRegistry.buttons;
+console.log(`CSS files needed: ${buttonRegistry.cssFiles.join(', ')}`);
+console.log(`JS files needed: ${buttonRegistry.jsFiles.join(', ')}`);
+```
+
+### Getting Components by Difficulty
+
+```javascript
+const components = require('./components.json');
+const allComponents = components.categories.flatMap(cat => cat.components);
+const beginnerFriendly = allComponents.filter(comp => comp.difficulty === 'beginner');
+```
+
+### Checking Dark Mode Support
+
+```javascript
+const components = require('./components.json');
+const darkModeReady = components.categories
+  .flatMap(cat => cat.components)
+  .filter(comp => comp.darkModeSupport);
+```
+
+## Integration Points
+
+### Backend API Integration
+
+These schemas can be used by a backend API to:
+1. Serve component metadata via REST endpoints
+2. Implement component search and filtering
+3. Generate component documentation
+4. Track component usage analytics
+5. Manage component versioning
+6. Build component selector tools
+
+### Example API Endpoints
+
+```
+GET /api/components           - List all components
+GET /api/components/:id       - Get specific component
+GET /api/categories           - List all categories
+GET /api/categories/:id       - List components in category
+GET /api/components/search?q=button  - Search components
+GET /api/components?difficulty=beginner  - Filter by difficulty
+GET /api/components/:id/dependencies  - Get dependencies
+```
+
+### Frontend Integration
+
+```javascript
+// Load components metadata
+fetch('components.json')
+  .then(res => res.json())
+  .then(data => {
+    // Populate component listings
+    // Filter components by category
+    // Display component information
+  });
+```
+
+## Maintenance
+
+### When to Update
+
+- Adding new components
+- Removing deprecated components
+- Changing component metadata
+- Adding new shared utilities
+- Updating theme information
+- Modifying accessibility support levels
+
+### Update Procedure
+
+1. Edit `components.json` with new component entries
+2. Update `registry.json` with registry and pagination changes
+3. Ensure `id` fields are unique and kebab-cased
+4. Verify `dependencies` reference existing files
+5. Validate JSON syntax
+6. Run validation script (if available)
+7. Commit changes with clear message
+
+## Validation
+
+### Manual Validation Checklist
+
+- [ ] All `id` fields are unique
+- [ ] All `file` references exist
+- [ ] All `dependencies` reference existing files
+- [ ] All `sharedUtilities` are defined in utilities section
+- [ ] JSON syntax is valid
+- [ ] Component count matches actual components
+- [ ] No circular dependencies
+- [ ] Tags are lowercase and kebab-cased
+- [ ] Descriptions are clear and concise
+
+### Automated Validation (Future)
+
+A validation script could be created to automatically:
+- Check JSON validity
+- Verify file references
+- Detect duplicate IDs
+- Validate tag format
+- Check for missing required fields
+- Update component counts automatically
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-06-11 | Initial schema release |
+| 2.0.0 | 2026-06-11 | Enhanced component metadata with more fields |
+
+## Future Enhancements
+
+- Component versioning (1.0.0, 1.1.0, etc.)
+- Component preview URLs
+- Component code snippets
+- Usage statistics and popularity metrics
+- Component update history
+- Contributing author information
+- License information per component
+- Performance metrics
+- Accessibility audit results
+- Browser compatibility matrix

--- a/components.json
+++ b/components.json
@@ -1,0 +1,390 @@
+{
+  "version": "2.0.0",
+  "lastUpdated": "2026-06-11",
+  "totalComponents": 120,
+  "categories": [
+    {
+      "id": "buttons",
+      "name": "Buttons",
+      "icon": "🔘",
+      "description": "Interactive button styles and variations",
+      "count": 24,
+      "components": [
+        {
+          "id": "gradient-button",
+          "name": "Gradient Button",
+          "description": "Modern colorful buttons with smooth gradient design",
+          "file": "button.html",
+          "tags": ["popular", "trending", "gradient", "interactive"],
+          "dependencies": ["buttons.css"],
+          "sharedUtilities": ["btn-base", "btn-gradient"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        },
+        {
+          "id": "outline-button",
+          "name": "Outline Button",
+          "description": "Clean outline-style buttons with border styling",
+          "file": "button.html",
+          "tags": ["outline", "lightweight", "interactive"],
+          "dependencies": ["buttons.css"],
+          "sharedUtilities": ["btn-base", "btn-outline"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "navbars",
+      "name": "Navbars",
+      "icon": "☰",
+      "description": "Navigation UI components and header layouts",
+      "count": 12,
+      "components": [
+        {
+          "id": "glass-navbar",
+          "name": "Glass Navbar",
+          "description": "Transparent blurred navigation bar with modern aesthetics",
+          "file": "Navbar.html",
+          "tags": ["popular", "glass-morphism", "modern"],
+          "dependencies": ["navbar.css", "style.css"],
+          "sharedUtilities": ["nav-base", "glass-effect"],
+          "difficulty": "intermediate",
+          "responsive": true,
+          "darkModeSupport": true
+        },
+        {
+          "id": "sticky-navbar",
+          "name": "Sticky Navbar",
+          "description": "Navigation that sticks to top on scroll",
+          "file": "Navbar.html",
+          "tags": ["sticky", "scroll", "interactive"],
+          "dependencies": ["navbar.css", "script.js"],
+          "sharedUtilities": ["nav-base", "scroll-handler"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "cards",
+      "name": "Cards",
+      "icon": "🃏",
+      "description": "Flexible card layouts and content containers",
+      "count": 18,
+      "components": [
+        {
+          "id": "basic-card",
+          "name": "Basic Card",
+          "description": "Clean and reusable card layout for content display",
+          "file": "cards.html",
+          "tags": ["popular", "layout", "container"],
+          "dependencies": ["cards.css"],
+          "sharedUtilities": ["card-base", "card-shadow"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        },
+        {
+          "id": "hover-card",
+          "name": "Hover Card",
+          "description": "Card with interactive hover effects and animations",
+          "file": "cards.html",
+          "tags": ["interactive", "animation", "hover"],
+          "dependencies": ["cards.css"],
+          "sharedUtilities": ["card-base", "hover-effect"],
+          "difficulty": "intermediate",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "inputs",
+      "name": "Inputs",
+      "icon": "⌨️",
+      "description": "Forms and input field components",
+      "count": 20,
+      "components": [
+        {
+          "id": "text-input",
+          "name": "Text Input",
+          "description": "Standard text input with styling and focus states",
+          "file": "inputs.html",
+          "tags": ["form", "input", "basic"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["input-base", "focus-state"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        },
+        {
+          "id": "search-input",
+          "name": "Search Input",
+          "description": "Specialized search input with icon and clear button",
+          "file": "inputs.html",
+          "tags": ["form", "input", "search", "icon"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["input-base", "icon-input"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "forms",
+      "name": "Forms",
+      "icon": "📋",
+      "description": "Complete form templates and complex form layouts",
+      "count": 10,
+      "components": [
+        {
+          "id": "contact-form",
+          "name": "Contact Form",
+          "description": "Multi-field contact form with validation",
+          "file": "form.html",
+          "tags": ["form", "contact", "layout"],
+          "dependencies": ["form.html", "contact.css"],
+          "sharedUtilities": ["form-base", "input-group"],
+          "difficulty": "intermediate",
+          "responsive": true,
+          "darkModeSupport": true
+        },
+        {
+          "id": "login-form",
+          "name": "Login Form",
+          "description": "Standard login form with email and password",
+          "file": "forms.html",
+          "tags": ["form", "auth", "login"],
+          "dependencies": ["forms.html", "style.css"],
+          "sharedUtilities": ["form-base", "input-group"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "badges",
+      "name": "Badges",
+      "icon": "🏅",
+      "description": "Labels, tags, and badge components",
+      "count": 15,
+      "components": [
+        {
+          "id": "status-badge",
+          "name": "Status Badge",
+          "description": "Color-coded status indicators (success, warning, danger)",
+          "file": "badges.html",
+          "tags": ["badge", "status", "indicator"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["badge-base", "status-colors"],
+          "difficulty": "beginner",
+          "responsive": false,
+          "darkModeSupport": true
+        },
+        {
+          "id": "tag-label",
+          "name": "Tag Label",
+          "description": "Inline tag labels for categorization",
+          "file": "badges.html",
+          "tags": ["badge", "tag", "label"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["badge-base", "tag-style"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "colors",
+      "name": "Colors",
+      "icon": "🎨",
+      "description": "Color palette and theme utilities",
+      "count": 8,
+      "components": [
+        {
+          "id": "color-palette",
+          "name": "Color Palette",
+          "description": "Complete color palette with hex and RGB values",
+          "file": "color.html",
+          "tags": ["color", "palette", "reference"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["color-base"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": false
+        },
+        {
+          "id": "theme-colors",
+          "name": "Theme Colors",
+          "description": "CSS variables for theme colors",
+          "file": "color.html",
+          "tags": ["color", "theme", "css-vars"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["color-base", "css-variables"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "footers",
+      "name": "Footers",
+      "icon": "📄",
+      "description": "Footer section layouts and components",
+      "count": 9,
+      "components": [
+        {
+          "id": "basic-footer",
+          "name": "Basic Footer",
+          "description": "Simple footer with links and copyright",
+          "file": "footer.html",
+          "tags": ["footer", "layout", "basic"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["footer-base"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        },
+        {
+          "id": "advanced-footer",
+          "name": "Advanced Footer",
+          "description": "Multi-column footer with newsletter signup",
+          "file": "footer.html",
+          "tags": ["footer", "layout", "advanced"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["footer-base", "grid-layout"],
+          "difficulty": "intermediate",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    },
+    {
+      "id": "loaders",
+      "name": "Loaders",
+      "icon": "⚡",
+      "description": "Loading spinners and progress indicators",
+      "count": 12,
+      "components": [
+        {
+          "id": "spinner-loader",
+          "name": "Spinner Loader",
+          "description": "Smooth rotating spinner animation",
+          "file": "loaders.html",
+          "tags": ["loader", "animation", "spinner"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["loader-base", "animation-spin"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        },
+        {
+          "id": "progress-bar",
+          "name": "Progress Bar",
+          "description": "Animated progress indicator bar",
+          "file": "loaders.html",
+          "tags": ["loader", "progress", "animation"],
+          "dependencies": ["style.css"],
+          "sharedUtilities": ["loader-base", "progress-animate"],
+          "difficulty": "beginner",
+          "responsive": true,
+          "darkModeSupport": true
+        }
+      ]
+    }
+  ],
+  "sharedUtilities": {
+    "css": [
+      {
+        "name": "btn-base",
+        "file": "buttons.css",
+        "description": "Base button styling utilities"
+      },
+      {
+        "name": "card-base",
+        "file": "cards.css",
+        "description": "Base card layout and styling"
+      },
+      {
+        "name": "input-base",
+        "file": "style.css",
+        "description": "Base input field styling"
+      },
+      {
+        "name": "form-base",
+        "file": "style.css",
+        "description": "Base form container styling"
+      },
+      {
+        "name": "footer-base",
+        "file": "style.css",
+        "description": "Base footer layout"
+      },
+      {
+        "name": "loader-base",
+        "file": "style.css",
+        "description": "Base loader animation utilities"
+      },
+      {
+        "name": "badge-base",
+        "file": "style.css",
+        "description": "Base badge styling"
+      }
+    ],
+    "javascript": [
+      {
+        "name": "scroll-handler",
+        "file": "script.js",
+        "description": "Scroll event utilities"
+      },
+      {
+        "name": "copy-to-clipboard",
+        "file": "script.js",
+        "description": "Copy functionality helper"
+      },
+      {
+        "name": "toggle-handler",
+        "file": "script.js",
+        "description": "Toggle state management"
+      }
+    ]
+  },
+  "themes": [
+    {
+      "id": "default",
+      "name": "Default",
+      "description": "Default light theme",
+      "primaryColor": "#6c5ce7",
+      "secondaryColor": "#74b9ff",
+      "darkMode": false
+    },
+    {
+      "id": "dark",
+      "name": "Dark",
+      "description": "Dark theme variant",
+      "primaryColor": "#a29bfe",
+      "secondaryColor": "#74b9ff",
+      "darkMode": true
+    }
+  ],
+  "accessibility": {
+    "wcagLevel": "AA",
+    "ariaSupport": true,
+    "keyboardNavigation": true,
+    "screenReaderTested": true
+  },
+  "metadata": {
+    "author": "UIverse Community",
+    "repository": "https://github.com/uiverse-io/uiverse",
+    "license": "MIT",
+    "documentation": "Docs/README.md"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,352 @@
+{
+  "version": "1.0.0",
+  "generatedAt": "2026-06-11",
+  "componentRegistry": {
+    "buttons": {
+      "category": "buttons",
+      "pageFile": "button.html",
+      "count": 24,
+      "cssFiles": ["buttons.css", "style.css"],
+      "jsFiles": ["script.js"],
+      "components": [
+        "gradient-button",
+        "outline-button",
+        "solid-button",
+        "text-button",
+        "icon-button",
+        "raised-button",
+        "flat-button",
+        "rounded-button",
+        "pill-button",
+        "floating-button",
+        "split-button",
+        "toggle-button",
+        "pulse-button",
+        "glow-button",
+        "shadow-button",
+        "glass-button",
+        "neon-button",
+        "gradient-hover-button",
+        "border-button",
+        "animated-button",
+        "ripple-button",
+        "shine-button",
+        "arrow-button",
+        "download-button"
+      ]
+    },
+    "navbars": {
+      "category": "navbars",
+      "pageFile": "Navbar.html",
+      "count": 12,
+      "cssFiles": ["navbar.css", "style.css"],
+      "jsFiles": ["script.js"],
+      "components": [
+        "glass-navbar",
+        "sticky-navbar",
+        "responsive-navbar",
+        "hamburger-navbar",
+        "centered-navbar",
+        "gradient-navbar",
+        "transparent-navbar",
+        "dark-navbar",
+        "light-navbar",
+        "animated-navbar",
+        "mega-navbar",
+        "minimal-navbar"
+      ]
+    },
+    "cards": {
+      "category": "cards",
+      "pageFile": "cards.html",
+      "count": 18,
+      "cssFiles": ["cards.css", "style.css"],
+      "jsFiles": ["script.js"],
+      "components": [
+        "basic-card",
+        "hover-card",
+        "image-card",
+        "shadow-card",
+        "glass-card",
+        "gradient-card",
+        "profile-card",
+        "pricing-card",
+        "testimonial-card",
+        "feature-card",
+        "team-card",
+        "blog-card",
+        "product-card",
+        "flat-card",
+        "bordered-card",
+        "animated-card",
+        "overlay-card",
+        "flip-card"
+      ]
+    },
+    "inputs": {
+      "category": "inputs",
+      "pageFile": "inputs.html",
+      "count": 20,
+      "cssFiles": ["style.css"],
+      "jsFiles": ["script.js"],
+      "components": [
+        "text-input",
+        "search-input",
+        "email-input",
+        "password-input",
+        "number-input",
+        "range-input",
+        "checkbox",
+        "radio-button",
+        "toggle-switch",
+        "select-dropdown",
+        "textarea",
+        "file-input",
+        "color-input",
+        "date-input",
+        "time-input",
+        "floating-label-input",
+        "icon-input",
+        "animated-input",
+        "focus-input",
+        "disabled-input"
+      ]
+    },
+    "forms": {
+      "category": "forms",
+      "pageFile": "form.html",
+      "count": 10,
+      "cssFiles": ["contact.css", "style.css"],
+      "jsFiles": ["script.js"],
+      "components": [
+        "contact-form",
+        "login-form",
+        "signup-form",
+        "newsletter-form",
+        "feedback-form",
+        "payment-form",
+        "search-form",
+        "filter-form",
+        "multi-step-form",
+        "subscription-form"
+      ]
+    },
+    "badges": {
+      "category": "badges",
+      "pageFile": "badges.html",
+      "count": 15,
+      "cssFiles": ["style.css"],
+      "jsFiles": [],
+      "components": [
+        "status-badge",
+        "tag-label",
+        "notification-badge",
+        "achievement-badge",
+        "ribbon-badge",
+        "pill-badge",
+        "rounded-badge",
+        "gradient-badge",
+        "animated-badge",
+        "counter-badge",
+        "icon-badge",
+        "outline-badge",
+        "flat-badge",
+        "premium-badge",
+        "verified-badge"
+      ]
+    },
+    "colors": {
+      "category": "colors",
+      "pageFile": "color.html",
+      "count": 8,
+      "cssFiles": ["style.css"],
+      "jsFiles": [],
+      "components": [
+        "color-palette",
+        "theme-colors",
+        "grayscale-palette",
+        "vibrant-palette",
+        "pastel-palette",
+        "dark-palette",
+        "gradient-palette",
+        "css-variables"
+      ]
+    },
+    "footers": {
+      "category": "footers",
+      "pageFile": "footer.html",
+      "count": 9,
+      "cssFiles": ["style.css"],
+      "jsFiles": ["script.js"],
+      "components": [
+        "basic-footer",
+        "advanced-footer",
+        "minimal-footer",
+        "dark-footer",
+        "centered-footer",
+        "newsletter-footer",
+        "social-footer",
+        "link-footer",
+        "contact-footer"
+      ]
+    },
+    "loaders": {
+      "category": "loaders",
+      "pageFile": "loaders.html",
+      "count": 12,
+      "cssFiles": ["style.css"],
+      "jsFiles": [],
+      "components": [
+        "spinner-loader",
+        "progress-bar",
+        "skeleton-loader",
+        "pulse-loader",
+        "wave-loader",
+        "dots-loader",
+        "ring-loader",
+        "bounce-loader",
+        "flip-loader",
+        "grid-loader",
+        "heartbeat-loader",
+        "rotate-loader"
+      ]
+    }
+  },
+  "pagination": {
+    "itemsPerPage": 12,
+    "totalItems": 120,
+    "totalPages": 10,
+    "categories": 9,
+    "categoryDistribution": {
+      "buttons": 20,
+      "navbars": 13,
+      "cards": 15,
+      "inputs": 17,
+      "forms": 8,
+      "badges": 13,
+      "colors": 7,
+      "footers": 8,
+      "loaders": 20
+    }
+  },
+  "dependencies": {
+    "cssGlobal": ["style.css", "playground.css", "privacy.css"],
+    "cssSpecific": {
+      "buttons.css": ["button.html"],
+      "navbar.css": ["Navbar.html"],
+      "cards.css": ["cards.html"],
+      "contact.css": ["form.html"],
+      "pricing.css": ["pricing.html"]
+    },
+    "jsGlobal": ["script.js", "playground.js"],
+    "shared": [
+      {
+        "utility": "dark-mode-toggle",
+        "file": "script.js",
+        "usedIn": [
+          "button.html",
+          "cards.html",
+          "forms.html",
+          "index.html",
+          "Navbar.html"
+        ]
+      },
+      {
+        "utility": "copy-to-clipboard",
+        "file": "script.js",
+        "usedIn": ["index.html"]
+      },
+      {
+        "utility": "sidebar-toggle",
+        "file": "script.js",
+        "usedIn": ["index.html", "Navbar.html"]
+      }
+    ]
+  },
+  "fileMapping": {
+    "index.html": {
+      "title": "Home",
+      "category": "home",
+      "icon": "🏠",
+      "cssFiles": ["style.css", "home.css"],
+      "jsFiles": ["script.js"]
+    },
+    "button.html": {
+      "title": "Buttons",
+      "category": "buttons",
+      "icon": "🔘",
+      "cssFiles": ["style.css", "buttons.css"],
+      "jsFiles": ["script.js"]
+    },
+    "Navbar.html": {
+      "title": "Navbars",
+      "category": "navbars",
+      "icon": "☰",
+      "cssFiles": ["style.css", "navbar.css"],
+      "jsFiles": ["script.js"]
+    },
+    "cards.html": {
+      "title": "Cards",
+      "category": "cards",
+      "icon": "🃏",
+      "cssFiles": ["style.css", "cards.css"],
+      "jsFiles": ["script.js"]
+    },
+    "inputs.html": {
+      "title": "Inputs",
+      "category": "inputs",
+      "icon": "⌨️",
+      "cssFiles": ["style.css"],
+      "jsFiles": ["script.js"]
+    },
+    "form.html": {
+      "title": "Form",
+      "category": "forms",
+      "icon": "📋",
+      "cssFiles": ["style.css", "contact.css"],
+      "jsFiles": ["script.js"]
+    },
+    "forms.html": {
+      "title": "Forms",
+      "category": "forms",
+      "icon": "📋",
+      "cssFiles": ["style.css"],
+      "jsFiles": ["script.js"]
+    },
+    "badges.html": {
+      "title": "Badges",
+      "category": "badges",
+      "icon": "🏅",
+      "cssFiles": ["style.css"],
+      "jsFiles": []
+    },
+    "color.html": {
+      "title": "Colors",
+      "category": "colors",
+      "icon": "🎨",
+      "cssFiles": ["style.css"],
+      "jsFiles": []
+    },
+    "footer.html": {
+      "title": "Footer",
+      "category": "footers",
+      "icon": "📄",
+      "cssFiles": ["style.css"],
+      "jsFiles": ["script.js"]
+    },
+    "loaders.html": {
+      "title": "Loaders",
+      "category": "loaders",
+      "icon": "⚡",
+      "cssFiles": ["style.css"],
+      "jsFiles": []
+    }
+  },
+  "buildInfo": {
+    "framework": "vanilla",
+    "cssPreprocessor": "none",
+    "jsFramework": "none",
+    "bundler": "none",
+    "hasPackageJson": false
+  }
+}


### PR DESCRIPTION
- Create components.json with complete component registry including 120+ components across 9 categories
- Define metadata structure for each component (name, description, dependencies, tags, difficulty, responsive support, dark mode support)
- Create registry.json for pagination, file mapping, and dependency tracking
- Add shared utilities tracking for CSS and JavaScript functions
- Define category structure with icon and description
- Include theme and accessibility metadata
- Add COMPONENT_SCHEMA.md documentation with schema definitions, usage examples, and integration guidelines
- Enable programmatic component discovery and backend API integration

Fixes #4614