### PR TITLE
Hardcoded inline styles breaking Dark Mode

### DIFF
--- a/span.html
+++ b/span.html
@@ -18,7 +18,7 @@
 <aside class="sidebar" id="sidebar">
   <div class="sidebar-brand">
     <span class="brand-icon">⬡</span>
-    <span class="brand-text">UIverse <span style="font-size: 9px; background: linear-gradient(135deg, #eb6835, #7b61ff); color: white; padding: 1px 6px; border-radius: 10px; font-weight: 800; margin-left: 4px; letter-spacing: 0.5px; vertical-align: middle; box-shadow: 0 0 8px rgba(235,104,53,0.3);">V2</span></span>
+    <span class="brand-text">UIverse <span class="text-primary" style="font-size: 9px; padding: 1px 6px; border-radius: 10px; font-weight: 800; margin-left: 4px; letter-spacing: 0.5px; vertical-align: middle; box-shadow: 0 0 8px rgba(235,104,53,0.3);">V2</span></span>
   </div>
 
           <nav class="sidebar-nav">

--- a/widgets.html
+++ b/widgets.html
@@ -455,28 +455,28 @@
         <div class="tech-stack-widget">
           <div class="tech-grid-layout">
             <div class="tech-item-node" style="--glow-color: rgba(97, 218, 251, 0.15);">
-              <div class="tech-icon-wrapper"><i class="fab fa-react" style="color: #61dafb;"></i></div>
+              <div class="tech-icon-wrapper"><i class="fab fa-react text-primary"></i></div>
               <div class="tech-details-block">
                 <h4>React Core</h4>
                 <span class="project-badge-tag">12 Active Projects</span>
               </div>
             </div>
             <div class="tech-item-node" style="--glow-color: rgba(49, 120, 198, 0.15);">
-              <div class="tech-icon-wrapper"><i class="fa-solid fa-code" style="color: #3178c6;"></i></div>
+              <div class="tech-icon-wrapper"><i class="fa-solid fa-code text-primary"></i></div>
               <div class="tech-details-block">
                 <h4>TypeScript Shell</h4>
                 <span class="project-badge-tag">18 Active Projects</span>
               </div>
             </div>
             <div class="tech-item-node" style="--glow-color: rgba(104, 160, 99, 0.15);">
-              <div class="tech-icon-wrapper"><i class="fab fa-node-js" style="color: #68a063;"></i></div>
+              <div class="tech-icon-wrapper"><i class="fab fa-node-js text-primary"></i></div>
               <div class="tech-details-block">
                 <h4>NodeJS Server</h4>
                 <span class="project-badge-tag">8 Active Projects</span>
               </div>
             </div>
             <div class="tech-item-node" style="--glow-color: rgba(51, 103, 145, 0.15);">
-              <div class="tech-icon-wrapper"><i class="fa-solid fa-database" style="color: #336791;"></i></div>
+              <div class="tech-icon-wrapper"><i class="fa-solid fa-database text-primary"></i></div>
               <div class="tech-details-block">
                 <h4>PostgreSQL Matrix</h4>
                 <span class="project-badge-tag">6 Active Projects</span>


### PR DESCRIPTION
Task: Fix issue #5206. Do NOT search the workspace, run generic find commands, or explore directories manually. Execute these exact steps:

1. Open exactly two files: `widgets.html` and `span.html`.
2. Scan both files for instances of hardcoded inline color styles (e.g., `style="color: #61dafb;"` or similar hex values on icons and text elements).
3. Remove all of these inline `style` attributes.
4. Add a standard utility class (e.g., `class="text-primary"` or the equivalent class used in this project) to those elements so they inherit the `var(--primary-color)` theme variable from the central CSS.
5. Once the inline styles are removed and replaced with theme-compatible classes in both files, save them and terminate the task immediately.
