### PR TITLE
 Unhandled localStorage Exceptions

### DIFF
--- a/timeline.js
+++ b/timeline.js
@@ -118,7 +118,13 @@ function initTheme() {
   if (!themeToggle) return;
   
   // Check user preference
-  const savedTheme = localStorage.getItem('theme');
+  let savedTheme = null;
+  try {
+    savedTheme = localStorage.getItem('theme');
+  } catch (e) {
+    console.warn('localStorage access denied. Falling back to non-persistent state.', e);
+  }
+
   const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   
   if (savedTheme === 'dark' || (!savedTheme && systemPrefersDark)) {
@@ -131,11 +137,19 @@ function initTheme() {
   
   themeToggle.addEventListener('click', () => {
     const isDark = document.body.classList.toggle('dark-mode');
+    try {
+      if (isDark) {
+        localStorage.setItem('theme', 'dark');
+      } else {
+        localStorage.setItem('theme', 'light');
+      }
+    } catch (e) {
+      console.warn('localStorage access denied. Falling back to non-persistent state.', e);
+    }
+
     if (isDark) {
-      localStorage.setItem('theme', 'dark');
       themeToggle.innerHTML = '<i class="fa-solid fa-sun"></i>';
     } else {
-      localStorage.setItem('theme', 'light');
       themeToggle.innerHTML = '<i class="fa-solid fa-moon"></i>';
     }
   });


### PR DESCRIPTION
## Related Issue
Closes #5200

## Summary
This pull request addresses a bug where unprotected `localStorage.setItem()` calls caused the application to throw fatal `SecurityError` or `QuotaExceededError` exceptions. This primarily impacted users on Safari Private Browsing mode or those with strict cookie-blocking extensions, causing the JavaScript execution thread to completely halt. By wrapping these storage interactions in a `try/catch` block, the application now fails gracefully and relies on non-persistent state management when storage access is denied.

## Changes Made
- [x] Added/modified the component file(s)
- [ ] Updated companion stylesheet/CSS file(s)
- [ ] Documented properties and usage in relevant markdown/docs

## Technical Details & Scope
- **Component Category:** Core / State Management
- **Impact Radius:** `timeline.js`. This prevents fatal crashes across the timeline component for users with restrictive browser configurations.

## Testing & Verification
Please describe how you verified the changes:
1. **Local Test Command:** Served the application locally.
2. **Browsers Checked:** Safari (Private Browsing Mode), Chrome (with "Block third-party cookies" enabled).
3. **Responsive Verification:** Toggled the theme in a restricted browser state and verified via the DevTools console that a warning is gracefully logged instead of throwing a fatal execution error.

## Accessibility & Theme Integration
- [ ] Contrast ratio checked for light and dark themes
- [ ] Focus outlines visible during keyboard navigation
- [ ] Semantic elements used instead of generic divs where appropriate
- [ ] Text descriptors (`aria-label`, alternate titles) provided

## Screenshots
*N/A — This is a backend JavaScript resilience fix. Visual rendering remains unchanged.*

## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
- [x] Component metadata version and changelog updated if necessary
