### PR TITLE
Trap Utility for Modals/Sidebars

### DIFF
--- a/focus-trap.js
+++ b/focus-trap.js
@@ -1,0 +1,27 @@
+export function focusTrap(element) {
+  const focusableElements = element.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  
+  if (focusableElements.length === 0) return;
+
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements[focusableElements.length - 1];
+
+  element.addEventListener('keydown', function(e) {
+    const isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+    if (!isTabPressed) return;
+
+    if (e.shiftKey) { 
+      if (document.activeElement === firstElement) {
+        lastElement.focus();
+        e.preventDefault();
+      }
+    } else { 
+      if (document.activeElement === lastElement) {
+        firstElement.focus();
+        e.preventDefault();
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Related Issue
Closes #5225

## Summary
This pull request introduces a shared `focusTrap` JavaScript utility to drastically improve keyboard navigation. Previously, users navigating via the `Tab` key would cycle right through an open sidebar or modal and interact with the hidden background page, breaking WCAG accessibility flows. This new utility locks the user's keyboard focus inside the active element until they explicitly close it, ensuring a standard, compliant navigation experience.

## Changes Made
- [x] Added/modified the component file(s) *(Created `focus-trap.js`)*
- [ ] Updated companion stylesheet/CSS file(s)
- [ ] Documented properties and usage in relevant markdown/docs

## Technical Details & Scope
- **Component Category:** Utility / Accessibility
- **Impact Radius:** `focus-trap.js`. This provides a reusable utility that can be imported and attached to any modal, sidebar, or overlay component across the application.

## Testing & Verification
Please describe how you verified the changes:
1. **Local Test Command:** Served the app locally and imported the utility into a test modal.
2. **Browsers Checked:** Chrome, Firefox, Safari
3. **Responsive Verification:** N/A (Keyboard routing logic)

## Accessibility & Theme Integration
- [ ] Contrast ratio checked for light and dark themes
- [x] Focus outlines visible during keyboard navigation *(Ensures trapped elements maintain visible browser focus)*
- [ ] Semantic elements used instead of generic divs where appropriate
- [ ] Text descriptors (`aria-label`, alternate titles) provided

## Screenshots
*N/A — This is a backend DOM interaction fix. Visuals remain unchanged, but keyboard flows are significantly improved.*

## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
- [x] Component metadata version and changelog updated if necessary
